### PR TITLE
Roll version for 0.3 development

### DIFF
--- a/cert-utils/pom.xml
+++ b/cert-utils/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>fido-iot</artifactId>
     <groupId>org.fido</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
 
   <name>Cert Utilities</name>
   <artifactId>cert-utils</artifactId>
@@ -20,7 +20,6 @@
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -32,8 +31,5 @@
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>${bcpkix.version}</version>
     </dependency>
-
   </dependencies>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>fido-iot</artifactId>
   <groupId>org.fido</groupId>
-  <version>1.9</version>
+  <version>0.3-SNAPSHOT</version>
   <name>fido-iot</name>
   <packaging>pom</packaging>
 
@@ -21,10 +21,8 @@
   -->
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     <junit-jupiter.version>5.6.1</junit-jupiter.version>
     <slf4j-api.version>1.7.30</slf4j-api.version>
-
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -2,18 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>fido-iot</artifactId>
     <groupId>org.fido</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>protocol</artifactId>
   <groupId>org.fido.iot</groupId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -24,10 +23,7 @@
     <bcpkix.version>1.65</bcpkix.version>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -37,7 +33,7 @@
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 
@@ -54,7 +50,5 @@
       <version>${bcpkix.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
-
 </project>

--- a/service/http-client-samples/http-client-di-sample/pom.xml
+++ b/service/http-client-samples/http-client-di-sample/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-client-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>HTTP Di Client</name>
   <artifactId>http-client-di-sample</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -24,30 +22,29 @@
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>
 
-
   <dependencies>
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>http-client-dispatcher</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>storage-di-sample</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -62,13 +59,11 @@
       <version>1.4.200</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -81,8 +76,6 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat.version}</version>
     </dependency>
-
-
   </dependencies>
 
   <build>
@@ -104,6 +97,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/service/http-client-samples/http-client-to0-sample/pom.xml
+++ b/service/http-client-samples/http-client-to0-sample/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-client-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>HTTP To0 Client</name>
   <artifactId>http-client-to0-sample</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -24,32 +22,30 @@
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>
 
-
-
   <dependencies>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>http-client-dispatcher</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>storage-rv-sample</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -64,13 +60,11 @@
       <version>1.4.200</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -83,9 +77,6 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat.version}</version>
     </dependency>
-
-
-
   </dependencies>
 
   <build>
@@ -107,6 +98,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/service/http-client-samples/http-client-to1-sample/pom.xml
+++ b/service/http-client-samples/http-client-to1-sample/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-client-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>HTTP To1 Client</name>
   <artifactId>http-client-to1-sample</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -24,30 +22,29 @@
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>
 
-
   <dependencies>
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>http-client-dispatcher</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>storage-rv-sample</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -62,13 +59,11 @@
       <version>1.4.200</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -81,9 +76,6 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat.version}</version>
     </dependency>
-
-
-
   </dependencies>
 
   <build>
@@ -105,6 +97,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/service/http-client-samples/http-client-to2-sample/pom.xml
+++ b/service/http-client-samples/http-client-to2-sample/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-client-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>HTTP To2 Client</name>
   <artifactId>http-client-to2-sample</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -24,30 +22,29 @@
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>
 
-
   <dependencies>
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>http-client-dispatcher</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>storage-owner-sample</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -62,13 +59,11 @@
       <version>1.4.200</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -102,6 +97,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/service/http-client-samples/pom.xml
+++ b/service/http-client-samples/pom.xml
@@ -2,12 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>service</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>http-client-samples</artifactId>
   <packaging>pom</packaging>

--- a/service/http-dispatchers/http-client-dispatcher/pom.xml
+++ b/service/http-dispatchers/http-client-dispatcher/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-dispatchers</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Http Client Dispatcher</name>
   <artifactId>http-client-dispatcher</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -25,29 +23,24 @@
     <exec.mainClass>org.sdo.web.RvApp</exec.mainClass>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
-
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -60,9 +53,6 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat.version}</version>
     </dependency>
-
-
-
   </dependencies>
 
   <build>
@@ -84,6 +74,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/service/http-dispatchers/http-server-dispatcher/pom.xml
+++ b/service/http-dispatchers/http-server-dispatcher/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-dispatchers</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Http server dispatcher</name>
   <artifactId>http-server-dispatcher</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -24,23 +22,18 @@
     <bcpkix.version>1.65</bcpkix.version>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
-
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -49,12 +42,10 @@
       <scope>provided</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>${bcpkix.version}</version>
-
     </dependency>
 
     <dependency>
@@ -63,7 +54,6 @@
       <version>${tomcat.version}</version>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
@@ -92,10 +82,5 @@
       <version>${tomcat.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
-
-
-
-
 </project>

--- a/service/http-dispatchers/pom.xml
+++ b/service/http-dispatchers/pom.xml
@@ -2,12 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>service</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>http-dispatchers</artifactId>
   <packaging>pom</packaging>

--- a/service/http-server-samples/http-server-di-sample/pom.xml
+++ b/service/http-server-samples/http-server-di-sample/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-server-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Http Device Initialization server</name>
   <artifactId>http-server-di-sample</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -25,32 +23,29 @@
     <exec.mainClass>org.fido.iot.web.DiApp</exec.mainClass>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>http-server-dispatcher</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>storage-di-sample</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -65,13 +60,11 @@
       <version>1.4.200</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -84,9 +77,6 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat.version}</version>
     </dependency>
-
-
-
   </dependencies>
 
   <build>

--- a/service/http-server-samples/http-server-owner-sample/pom.xml
+++ b/service/http-server-samples/http-server-owner-sample/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-server-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Http Owner server</name>
   <artifactId>http-server-owner-sample</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -25,32 +23,29 @@
     <exec.mainClass>org.fido.iot.web.OwnerApp</exec.mainClass>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>http-server-dispatcher</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>storage-owner-sample</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -65,13 +60,11 @@
       <version>1.4.200</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -84,8 +77,6 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat.version}</version>
     </dependency>
-
-
   </dependencies>
 
   <build>
@@ -107,6 +98,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/service/http-server-samples/http-server-rv-sample/pom.xml
+++ b/service/http-server-samples/http-server-rv-sample/pom.xml
@@ -2,19 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>http-server-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Http Rendezvous server</name>
   <artifactId>http-server-rv-sample</artifactId>
   <packaging>jar</packaging>
-
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
@@ -25,32 +23,29 @@
     <exec.mainClass>org.fido.iot.web.RvsApp</exec.mainClass>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>http-server-dispatcher</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>storage-rv-sample</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -65,13 +60,11 @@
       <version>1.4.200</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -84,9 +77,6 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat.version}</version>
     </dependency>
-
-
-
   </dependencies>
 
   <build>
@@ -108,6 +98,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/service/http-server-samples/pom.xml
+++ b/service/http-server-samples/pom.xml
@@ -2,20 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>service</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>http-server-samples</artifactId>
   <packaging>pom</packaging>
 
   <modules>
-  <module>http-server-di-sample</module>
-  <module>http-server-rv-sample</module>
-  <module>http-server-owner-sample</module>
+    <module>http-server-di-sample</module>
+    <module>http-server-rv-sample</module>
+    <module>http-server-owner-sample</module>
   </modules>
 
 </project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -2,15 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <artifactId>fido-iot</artifactId>
     <groupId>org.fido</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>service</name>
   <artifactId>service</artifactId>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -2,14 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>fido-iot</artifactId>
     <groupId>org.fido</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Storage</name>
   <artifactId>storage</artifactId>
@@ -19,6 +18,4 @@
   <modules>
     <module>storage-samples</module>
   </modules>
-
-
 </project>

--- a/storage/storage-samples/pom.xml
+++ b/storage/storage-samples/pom.xml
@@ -2,14 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>storage</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Storage samples</name>
   <artifactId>storage-samples</artifactId>
@@ -21,6 +20,4 @@
     <module>storage-owner-sample</module>
     <module>storage-rv-sample</module>
   </modules>
-
-
 </project>

--- a/storage/storage-samples/storage-di-sample/pom.xml
+++ b/storage/storage-samples/storage-di-sample/pom.xml
@@ -2,14 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>storage-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Storage Device Initialization Sample</name>
   <artifactId>storage-di-sample</artifactId>
@@ -24,23 +23,19 @@
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
-
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -61,17 +56,10 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>${bcpkix.version}</version>
-
     </dependency>
-
   </dependencies>
-
-
-
-
 </project>

--- a/storage/storage-samples/storage-owner-sample/pom.xml
+++ b/storage/storage-samples/storage-owner-sample/pom.xml
@@ -2,14 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>storage-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Storage Owner Sample</name>
   <artifactId>storage-owner-sample</artifactId>
@@ -24,16 +23,12 @@
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
-
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -54,23 +49,17 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>${bcpkix.version}</version>
-
     </dependency>
+
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
-
-
-
-
 </project>

--- a/storage/storage-samples/storage-rv-sample/pom.xml
+++ b/storage/storage-samples/storage-rv-sample/pom.xml
@@ -2,14 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <artifactId>storage-samples</artifactId>
     <groupId>org.fido.iot</groupId>
-    <version>1.9</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
-
 
   <name>Storage Rendezvous Sample</name>
   <artifactId>storage-rv-sample</artifactId>
@@ -23,16 +22,12 @@
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>
 
-
-
   <dependencies>
-
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
     </dependency>
-
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -53,23 +48,17 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>${bcpkix.version}</version>
-
     </dependency>
+
     <dependency>
       <groupId>org.fido.iot</groupId>
       <artifactId>cert-utils</artifactId>
-      <version>1.9</version>
+      <version>0.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
-
-
-
-
 </project>


### PR DESCRIPTION
This is the third development cycle for new protocol (known as FIDO-IoT
going forward). The previous 2 TAGs can be considered as 0.1 and 0.2
release and this release can be considered as 0.3 release of the
preliminary implementation.

The version is rolled to 0.3-SNAPSHOT to enable development for this
cycle.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>