### PR TITLE
Added storage call to get HMAC replacement key and update credentials

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/To2ClientService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To2ClientService.java
@@ -6,7 +6,9 @@ package org.fido.iot.protocol;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.PublicKey;
+import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.UUID;
 
 /**
  * To2 Client message processing service.
@@ -34,6 +36,10 @@ public abstract class To2ClientService extends DeviceService {
 
   protected Composite getVoucherHeader() {
     return voucherHdr;
+  }
+
+  protected Composite getHeaderHash() {
+    return hdrHash;
   }
 
   protected void verifyEntry(int entryNum, Composite entry) {
@@ -221,10 +227,80 @@ public abstract class To2ClientService extends DeviceService {
   protected void doSetupDevice(Composite request, Composite reply) {
     getStorage().continuing(request, reply);
 
-    Composite payload = Composite.newArray()
-        .set(Const.FIRST_KEY, getStorage().getReplacementHmac());
+    Composite body = request.getAsComposite(Const.SM_BODY);
+    Composite message = Composite.fromObject(getCryptoService().decrypt(body, this.ownState));
 
-    Composite body = getCryptoService().encrypt(payload.toBytes(), this.ownState);
+    byte[] receivedNonce7 = message.getAsBytes(Const.THIRD_KEY);
+    getCryptoService().verifyBytes(receivedNonce7, nonce7);
+
+    Composite ownerKey2 = message.getAsComposite(Const.FOURTH_KEY);
+    Composite oldCreds = getStorage().getDeviceCredentials();
+    Composite newCreds = Composite.newArray()
+
+        .set(Const.DC_PROTVER,
+            oldCreds.getAsNumber(Const.DC_PROTVER))
+        .set(Const.DC_HMAC_SECRET,
+            oldCreds.getAsBytes(Const.DC_HMAC_SECRET))
+        .set(Const.DC_DEVICE_INFO,
+            oldCreds.getAsString(Const.DC_DEVICE_INFO))
+        .set(Const.DC_GUID,
+            oldCreds.getAsBytes(Const.DC_GUID))
+        .set(Const.DC_RENDEZVOUS_INFO,
+            oldCreds.getAsComposite(Const.DC_RENDEZVOUS_INFO));
+
+    PublicKey mfgPubKey = getCryptoService().decode(ownerKey2);
+    int hashType = getCryptoService().getCompatibleHashType(mfgPubKey);
+    Composite pubKeyHash = getCryptoService().hash(hashType, ownerKey2.toBytes());
+    getStorage().getDeviceCredentials().set(Const.DC_PUBLIC_KEY_HASH,
+        pubKeyHash);
+
+    //check for credential reuse
+    boolean isReuse = true;
+
+    //check if GUIDs equal
+    UUID guid1 = oldCreds.getAsUuid((Const.DC_GUID));
+    UUID guid2 = newCreds.getAsUuid(Const.DC_GUID);
+    if (guid1.compareTo(guid2) != 0) {
+      isReuse = false;
+    }
+    //check if owner key equal
+    if (isReuse) {
+      PublicKey publicKey1 = getCryptoService().decode(cupKey);
+      PublicKey publicKey2 = getCryptoService().decode(ownerKey2);
+      if (getCryptoService().compare(publicKey1, publicKey2) != 0) {
+        isReuse = false;
+      }
+    }
+
+    //check if rvinfo equal
+    if (isReuse) {
+      byte[] info1 = oldCreds.getAsComposite(Const.DC_RENDEZVOUS_INFO).toBytes();
+      byte[] info2 = newCreds.getAsComposite(Const.DC_RENDEZVOUS_INFO).toBytes();
+      if (Arrays.compare(info1, info2) != 0) {
+        isReuse = false;
+      }
+    }
+
+    byte[] secret = getStorage().getReplacementHmacSecret(newCreds, isReuse);
+    Composite newHash = null;
+
+    if (secret != null) {
+      Composite headerCopy = Composite.newArray();
+      headerCopy.set(Const.OVH_VERSION, voucherHdr.get(Const.OVH_VERSION));
+      headerCopy.set(Const.OVH_GUID, message.getAsUuid(Const.SECOND_KEY));
+      headerCopy.set(Const.OVH_RENDEZVOUS_INFO, message.getAsUuid(Const.FIRST_KEY));
+      headerCopy.set(Const.OVH_DEVICE_INFO, voucherHdr.get(Const.OVH_DEVICE_INFO));
+      headerCopy.set(Const.OVH_PUB_KEY, ownerKey2);
+      headerCopy.set(Const.OVH_CERT_CHAIN_HASH, voucherHdr.get(Const.OVH_CERT_CHAIN_HASH));
+      hashType = getHeaderHash().getAsNumber(Const.HASH_TYPE).intValue();
+      newHash = getCryptoService().hash(hashType, secret, headerCopy.toBytes());
+    }
+
+    Composite payload = Composite.newArray()
+        .set(Const.FIRST_KEY,
+            newHash);
+
+    body = getCryptoService().encrypt(payload.toBytes(), this.ownState);
 
     reply.set(Const.SM_MSG_ID, Const.TO2_AUTH_DONE);
     reply.set(Const.SM_BODY, body);

--- a/protocol/src/main/java/org/fido/iot/protocol/To2ClientStorage.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To2ClientStorage.java
@@ -20,7 +20,7 @@ public interface To2ClientStorage extends StorageEvents, DeviceCredentials {
 
   String getCipherSuiteName();
 
-  Composite getReplacementHmac();
+  byte[] getReplacementHmacSecret(Composite newCredentials,boolean isReuse);
 
   void prepareServiceInfo();
 

--- a/protocol/src/main/java/org/fido/iot/protocol/To2ServerService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To2ServerService.java
@@ -114,10 +114,27 @@ public abstract class To2ServerService extends MessagingService {
     getStorage().setNonce7(nonce7);
 
     payload = Composite.newArray();
-    payload.set(Const.FIRST_KEY, getStorage().getReplacementRvInfo());
-    payload.set(Const.SECOND_KEY, getStorage().getReplacementGuid());
-    payload.set(Const.THIRD_KEY, getStorage().getNonce6());
-    payload.set(Const.FOURTH_KEY, getStorage().getReplacementOwnerKey());
+
+    Composite replacementRvInfo = getStorage().getReplacementRvInfo();
+    if (replacementRvInfo == null) {
+      Composite ovh = voucher.getAsComposite(Const.OV_HEADER);
+      replacementRvInfo = ovh.getAsComposite(Const.OVH_RENDEZVOUS_INFO);
+    }
+
+    UUID replacementGuid = getStorage().getReplacementGuid();
+    if (replacementGuid == null) {
+      Composite ovh = voucher.getAsComposite(Const.OV_HEADER);
+      replacementGuid = ovh.getAsUuid(Const.OVH_GUID);
+    }
+    Composite replacementKey = getStorage().getReplacementOwnerKey();
+    if (replacementKey == null) {
+      replacementKey = getCryptoService().getOwnerPublicKey(voucher);
+    }
+
+    payload.set(Const.FIRST_KEY, replacementRvInfo);
+    payload.set(Const.SECOND_KEY, replacementGuid);
+    payload.set(Const.THIRD_KEY, nonce7);
+    payload.set(Const.FOURTH_KEY, replacementKey);
 
     body = getCryptoService().encrypt(
         payload.toBytes(),

--- a/protocol/src/test/java/org/fido/iot/protocol/To2Test.java
+++ b/protocol/src/test/java/org/fido/iot/protocol/To2Test.java
@@ -78,7 +78,7 @@ public class To2Test extends BaseTemplate {
       }
 
       @Override
-      public Composite getReplacementHmac() {
+      public byte[] getReplacementHmacSecret(Composite newCredentials, boolean isReuse) {
         return null;
       }
 

--- a/service/http-client-samples/http-client-to2-sample/src/main/java/org/fido/iot/web/To2ClientApp.java
+++ b/service/http-client-samples/http-client-to2-sample/src/main/java/org/fido/iot/web/To2ClientApp.java
@@ -160,7 +160,7 @@ public class To2ClientApp {
     }
 
     @Override
-    public Composite getReplacementHmac() {
+    public byte[] getReplacementHmacSecret(Composite newCredentials, boolean isReuse) {
       return null;
     }
 

--- a/storage/storage-samples/storage-owner-sample/src/test/java/org/fido/iot/storage/To2StorageTest.java
+++ b/storage/storage-samples/storage-owner-sample/src/test/java/org/fido/iot/storage/To2StorageTest.java
@@ -225,7 +225,7 @@ public class To2StorageTest {
       }
 
       @Override
-      public Composite getReplacementHmac() {
+      public byte[] getReplacementHmacSecret(Composite newCredentials, boolean isReuse) {
         return null;
       }
 


### PR DESCRIPTION
Storage client updates credentials and checks for credential re-use protocol.
Client has choice to support re-use by returning null for the replacement HMAC
or to go ahead and return a new HMAC.

Signed-off-by: Templeton, Randall <randall.f.templeton@intel.com>