### PR TITLE
Make fromBytes() public.

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/Composite.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/Composite.java
@@ -382,7 +382,7 @@ public class Composite {
    * @param buffer The cbor byte buffer.
    * @return A Composite created from the cbor buffer.
    */
-  private static Composite fromBytes(byte[] buffer) {
+  public static Composite fromBytes(byte[] buffer) {
 
     ByteArrayInputStream in = new ByteArrayInputStream(buffer);
 


### PR DESCRIPTION
External modules (like HTTP transport) need to convert byte streams
into composites: for instance, when decoding error messages.