### PR TITLE
Add COSE algorithm id to sign method argument list

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
@@ -584,18 +584,18 @@ public class CryptoService {
    *
    * @param signingKey The signing key.
    * @param payload    The payload to sign.
+   * @param coseSignatureAlg The COSE algorithm that determines the signature algorithm.
    * @return The resulting COSE Signature.
    */
-  public Composite sign(PrivateKey signingKey, byte[] payload) {
+  public Composite sign(PrivateKey signingKey, byte[] payload, int coseSignatureAlg) {
 
-    final int algId = getCoseAlgorithm(signingKey);
     final Composite cos = Composite.newArray()
-        .set(Const.COSE_SIGN1_PROTECTED, Composite.newMap().set(Const.COSE_ALG, algId))
+        .set(Const.COSE_SIGN1_PROTECTED, Composite.newMap().set(Const.COSE_ALG, coseSignatureAlg))
         .set(Const.COSE_SIGN1_UNPROTECTED, Const.EMPTY_BYTE)
         .set(Const.COSE_SIGN1_PAYLOAD, payload);
 
     try {
-      final String algName = getSignatureAlgorithm(algId);
+      final String algName = getSignatureAlgorithm(coseSignatureAlg);
 
       final Signature signer = getSignatureInstance(algName);
       signer.initSign(signingKey);

--- a/protocol/src/main/java/org/fido/iot/protocol/To0ClientService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To0ClientService.java
@@ -48,7 +48,8 @@ public abstract class To0ClientService extends ClientService {
     Composite singedBlob = null;
     try (CloseableKey key = new CloseableKey(
         getStorage().getOwnerSigningKey(ownerPublicKey))) {
-      singedBlob = getCryptoService().sign(key.get(), to01Payload.toBytes());
+      singedBlob = getCryptoService().sign(
+          key.get(), to01Payload.toBytes(), getCryptoService().getCoseAlgorithm(ownerPublicKey));
     } catch (IOException e) {
       throw new DispatchException(e);
     }

--- a/protocol/src/main/java/org/fido/iot/protocol/To1ClientService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To1ClientService.java
@@ -29,7 +29,8 @@ public abstract class To1ClientService extends DeviceService {
 
     Composite signature = null;
     try (CloseableKey key = new CloseableKey(getStorage().getSigningKey())) {
-      signature = getCryptoService().sign(key.get(), payload.toBytes());
+      signature = getCryptoService().sign(
+          key.get(), payload.toBytes(), getCryptoService().getCoseAlgorithm(key.get()));
     } catch (IOException e) {
       throw new DispatchException(e);
     }

--- a/protocol/src/main/java/org/fido/iot/protocol/To2ClientService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To2ClientService.java
@@ -103,7 +103,8 @@ public abstract class To2ClientService extends DeviceService {
 
       Composite signature = null;
       try (CloseableKey key = new CloseableKey(getStorage().getSigningKey())) {
-        signature = getCryptoService().sign(key.get(), payload.toBytes());
+        signature = getCryptoService().sign(
+            key.get(), payload.toBytes(), getCryptoService().getCoseAlgorithm(key.get()));
       } catch (IOException e) {
         throw new DispatchException(e);
       }

--- a/protocol/src/main/java/org/fido/iot/protocol/To2ServerService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To2ServerService.java
@@ -54,7 +54,8 @@ public abstract class To2ServerService extends MessagingService {
     Composite cose = null;
     try (CloseableKey key = new CloseableKey(
         getStorage().geOwnerSigningKey(ownerPublicKey))) {
-      cose = getCryptoService().sign(key.get(), payload.toBytes());
+      cose = getCryptoService().sign(
+          key.get(), payload.toBytes(), getCryptoService().getCoseAlgorithm(ownerPublicKey));
     } catch (IOException e) {
       throw new DispatchException(e);
     }

--- a/protocol/src/main/java/org/fido/iot/protocol/VoucherExtensionService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/VoucherExtensionService.java
@@ -62,7 +62,8 @@ public class VoucherExtensionService {
     payload.set(Const.OVE_HASH_PREV_ENTRY, prevHash);
     payload.set(Const.OVE_HASH_HDR_INFO, hdrHash);
     payload.set(Const.OVE_PUB_KEY, cryptoService.encode(newOwner, Const.PK_ENC_COSEEC));
-    Composite cos = cryptoService.sign(prevOwner, payload.toBytes());
+    Composite cos = cryptoService.sign(
+        prevOwner, payload.toBytes(), cryptoService.getCoseAlgorithm(prevOwner));
 
     //The current recommended maximum is ten entries.
     entries.set(entries.size(), cos);

--- a/protocol/src/test/java/org/fido/iot/protocol/Ec256Test.java
+++ b/protocol/src/test/java/org/fido/iot/protocol/Ec256Test.java
@@ -41,7 +41,7 @@ public class Ec256Test {
     PublicKey p2 = service.decode(pub);
     assertTrue(service.compare(publicKey, p2) == 0);
 
-    Composite cos = service.sign(privateKey, payload);
+    Composite cos = service.sign(privateKey, payload, service.getCoseAlgorithm(privateKey));
 
     assertTrue(service.verify(publicKey, cos));
 

--- a/protocol/src/test/java/org/fido/iot/protocol/Ec384Test.java
+++ b/protocol/src/test/java/org/fido/iot/protocol/Ec384Test.java
@@ -51,7 +51,7 @@ public class Ec384Test {
     PublicKey p2 = service.decode(pub);
     assertTrue(service.compare(publicKey, p2) == 0);
 
-    Composite cos = service.sign(privateKey, payload);
+    Composite cos = service.sign(privateKey, payload, service.getCoseAlgorithm(privateKey));
 
     assertTrue(service.verify(publicKey, cos));
 


### PR DESCRIPTION
Updating the sign() method's argument list by adding the COSE signature
algorithm to be used, instead of determining the same inside the method.
This enables us to use public key to determine the field-size/
modulus-bit-length for EC and RSA keys.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>