### PR TITLE
Add owner port to default rendezvous

### DIFF
--- a/storage/storage-samples/storage-di-sample/src/main/java/org/fido/iot/storage/DiDbManager.java
+++ b/storage/storage-samples/storage-di-sample/src/main/java/org/fido/iot/storage/DiDbManager.java
@@ -70,7 +70,7 @@ public class DiDbManager {
                 + "ID,"
                 + "CERTIFICATE_VALIDITY_DAYS,"
                 + "RENDEZVOUS_INFO) "
-                + "VALUES (1,'3650','http://localhost:8040?ipaddress=127.0.0.1');";
+                + "VALUES (1,'3650','http://localhost:8040?ipaddress=127.0.0.1&ownerport=8040');";
             stmt.executeUpdate(sql);
           }
 


### PR DESCRIPTION
It is most common for owner and device rendezvous ports to be identical.
Letting the owner-port default to 80 causes the PRI to fail in TO0.
Include the owner port in the default rendezvous so the PRI will work
out of the box.

Signed-off-by: Greg Bean <greg.bean@intel.com>