### PR TITLE
Fix: fetch the correct EC curve name when verifying

### DIFF
--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -20,7 +20,7 @@
     <jackson-datatype-jdk8.version>2.11.0</jackson-datatype-jdk8.version>
     <commons-codec.version>1.14</commons-codec.version>
     <tomcat.version>9.0.24</tomcat.version>
-    <bcprov.version>1.65.01</bcprov.version>
+    <bcprov.version>1.66</bcprov.version>
     <bcpkix.version>1.65</bcpkix.version>
   </properties>
 
@@ -43,6 +43,12 @@
       <artifactId>commons-codec</artifactId>
       <version>${commons-codec.version}</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>${bcprov.version}</version>
     </dependency>
 
     <dependency>

--- a/protocol/src/main/java/org/fido/iot/protocol/Const.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/Const.java
@@ -178,6 +178,7 @@ public final class Const {
   public static final String VALIDATOR_ALG_NAME = "PKIX";
 
   //EC curve names
+  public static final String PRIME256V1_CURVE_NAME = "prime256v1";
   public static final String SECP256R1_CURVE_NAME = "secp256r1";
   public static final String SECP384R1_CURVE_NAME = "secp384r1";
 

--- a/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
@@ -40,6 +40,7 @@ import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
@@ -59,6 +60,7 @@ import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import org.bouncycastle.jce.spec.ECNamedCurveSpec;
 
 /**
  * Cryptography Service.
@@ -601,6 +603,7 @@ public class CryptoService {
    */
   private void verifyCurveName(String ecdsaCurveName) throws InvalidOwnershipVoucherException {
     if (!(ecdsaCurveName.contains(Const.SECP256R1_CURVE_NAME)
+        || ecdsaCurveName.contains(Const.PRIME256V1_CURVE_NAME)
         || ecdsaCurveName.contains(Const.SECP384R1_CURVE_NAME))) {
       throw new InvalidOwnershipVoucherException("Mismatch of ECDSA curve type.");
     }
@@ -627,7 +630,15 @@ public class CryptoService {
     String publicKeyAlgorithm = cert.getPublicKey().getAlgorithm();
     verifyAlgorithm(publicKeyAlgorithm);
 
-    String ecdsaCurveName = ((ECPublicKey) cert.getPublicKey()).getParams().toString();
+    String ecdsaCurveName;
+    ECParameterSpec p = ((ECPublicKey) cert.getPublicKey()).getParams();
+    if (p instanceof ECNamedCurveSpec) {
+      ECNamedCurveSpec ncs = (ECNamedCurveSpec)p;
+      ecdsaCurveName = ncs.getName();
+    } else {
+      ecdsaCurveName = p.toString();
+    }
+
     verifyCurveName(ecdsaCurveName);
 
     int pubKeySize =


### PR DESCRIPTION
When EC parameter field toString() is called on bouncycastle
ECNamedCurveSpec objects, it produces a java-style "class@address"
string, which is not what we want.

Instead, fetch and test the curve name field from the parameter
spec object if it's a bouncycastle object.

Accept the legacy name for secp256r1: prime256v1.

Signed-off-by: Greg Bean <greg.bean@intel.com>