### PR TITLE
Adding MAROE Prefix verification.

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/Const.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/Const.java
@@ -210,6 +210,9 @@ public final class Const {
   public static final String URL_PATH_SEPARATOR = "/";
   public static final String EPID_PROOF_URI_PATH = "proof";
 
+  // MAROE Prefix List
+  public static final String[] MAROE_PREFIX_LIST = {"e2cb06bd11a323419d1d3563b809bc46"};
+
   //OwnershipVoucher
   public static final int OV_HEADER = 0;
   public static final int OV_HMAC = 1;

--- a/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
@@ -579,6 +579,26 @@ public class CryptoService {
   }
 
   /**
+   * Verifies MAROE Prefix.
+   *
+   * @param cose The COSE message
+   */
+  public void verifyMaroePrefix(Composite cose) {
+    Composite uph = cose.getAsComposite(Const.COSE_SIGN1_UNPROTECTED);
+    String maroePrefix = Composite.toString(uph.getAsBytes(Const.EAT_MAROE_PREFIX));
+    boolean isMaroePrefixValid = false;
+    for (final String maroePrefixItem : Const.MAROE_PREFIX_LIST) {
+      if (maroePrefix.equals(maroePrefixItem)) {
+        isMaroePrefixValid = true;
+        break;
+      }
+    }
+    if (!isMaroePrefixValid) {
+      throw new RuntimeException("Invalid MAROE Prefix");
+    }
+  }
+
+  /**
    * Verifies a COSE signature.
    *
    * @param verificationKey The verification key to use.
@@ -589,6 +609,7 @@ public class CryptoService {
   public boolean verify(PublicKey verificationKey, Composite cose, Composite sigInfoA) {
     if (null != sigInfoA && Arrays.asList(Const.SG_EPIDv10, Const.SG_EPIDv11, Const.SG_EPIDv20)
         .contains(sigInfoA.getAsNumber(Const.FIRST_KEY).intValue())) {
+      verifyMaroePrefix(cose);
       return EpidSignatureVerifier.verify(cose, sigInfoA);
     }
     final Composite header1 = cose.getAsComposite(Const.COSE_SIGN1_PROTECTED);


### PR DESCRIPTION
- MAROE Prefix verification added for msg/32 and msg/64 for
EPID devices.
- Added verifyMaroePrefix function in cryptoService class.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>