### PR TITLE
Update handling of To0Client of Component Owner

### DIFF
--- a/demo/owner/owner.env
+++ b/demo/owner/owner.env
@@ -5,4 +5,6 @@ owner_database_password=
 owner_database_port=8051
 catalina_home=./target/tomcat
 owner_keystore_password=OnrKstr1
-owner_to0_scheduling_enabled=false
+owner_to0_scheduling_enabled=true
+owner_to0_scheduling_interval=300
+owner_to0_rv_blob=http://localhost:8042?ipaddress=127.0.0.1

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerAppConstants.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerAppConstants.java
@@ -8,10 +8,10 @@ public class OwnerAppConstants {
 
   // the port at which Owner is listening for TO2
   public static final String TO2_PORT = "owner_to2_port";
-  
+
   // part of the path of exposed web APIs
   public static final String WEB_PATH = "/fido/100/msg";
-  
+
   // H2 database configuration keys and constants
   public static final String DB_URL = "owner_database_connection_url";
   public static final String DB_USER = "owner_database_username";
@@ -21,16 +21,16 @@ public class OwnerAppConstants {
 
   // tomcat's catalaina.home
   public static final String SERVER_PATH = "catalina_home";
-  
+
   // the user pin for HSM keystore that contains the owner keys
   public static final String OWNER_KEYSTORE_PWD = "owner_keystore_password";
-  
+
   // the owner keystore type
   public static final String OWNER_KEYSTORE_TYPE = "PKCS11";
 
-  // default TO0 waitseconds
-  public static final int TO0_REQUEST_WS = 3600;
-  
+  public static final String TO0_RV_BLOB = "owner_to0_rv_blob";
+
   public static final String TO0_SCHEDULING_ENABLED = "owner_to0_scheduling_enabled";
-  
+
+  public static final String TO0_SCHEDULING_INTREVAL = "owner_to0_scheduling_interval";
 }

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerContextListener.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerContextListener.java
@@ -6,16 +6,11 @@ package org.fido.iot.sample;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.util.Arrays;
-import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +21,6 @@ import javax.servlet.ServletContextListener;
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.fido.iot.certutils.PemLoader;
 import org.fido.iot.protocol.Composite;
 import org.fido.iot.protocol.Const;
 import org.fido.iot.protocol.CryptoService;
@@ -37,6 +31,7 @@ import org.fido.iot.protocol.To2ServerService;
 import org.fido.iot.protocol.To2ServerStorage;
 import org.fido.iot.storage.OwnerDbManager;
 import org.fido.iot.storage.OwnerDbStorage;
+import org.fido.iot.storage.OwnerDbTo0Util;
 
 /**
  * TO2 Servlet Context Listener.
@@ -72,6 +67,7 @@ public class OwnerContextListener implements ServletContextListener {
 
   private KeyResolver resolver;
   private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+  private ExecutorService to0ExecutorService = Executors.newCachedThreadPool();
 
   @Override
   public void contextInitialized(ServletContextEvent sce) {
@@ -126,23 +122,26 @@ public class OwnerContextListener implements ServletContextListener {
     OwnerDbManager manager = new OwnerDbManager();
     manager.createTables(ds);
     manager.importVoucher(ds, Composite.fromObject(VOUCHER));
-    
+
     // schedule devices for TO0 only if the flag is set
     if (Boolean.valueOf(sc.getInitParameter(OwnerAppConstants.TO0_SCHEDULING_ENABLED))) {
       scheduler.scheduleWithFixedDelay(new Runnable() {
         @Override
         public void run() {
           try {
-            // to-do: add code to search DB for devices that needs scheduling and update TO0Client
-            // accordingly
-            new OwnerTo0Client(new CryptoService(),
-                new OwnerKeyResolver(sc.getInitParameter(OwnerAppConstants.OWNER_KEYSTORE_PWD)))
-                    .run();
+            OwnerDbTo0Util to0Util = new OwnerDbTo0Util();
+            List<UUID> uuids = to0Util.fetchDevicesForTo0(ds);
+            sc.log("Scheduling UUIDs for TO0: " + uuids.toString());
+            for (UUID guid : uuids) {
+              CompletableFuture.runAsync(() -> scheduleTo0(sc, ds, guid, to0Util),
+                  to0ExecutorService);
+            }
           } catch (Exception e) {
             sc.log(e.getMessage());
           }
         }
-      }, 5, 300, TimeUnit.SECONDS);
+      }, 5, Integer.parseInt(
+          sc.getInitParameter(OwnerAppConstants.TO0_SCHEDULING_INTREVAL)), TimeUnit.SECONDS);
     }
   }
 
@@ -167,5 +166,18 @@ public class OwnerContextListener implements ServletContextListener {
         return cs;
       }
     };
+  }
+
+  private void scheduleTo0(ServletContext sc, DataSource ds, UUID guid, OwnerDbTo0Util to0Util) {
+    try {
+      OwnerTo0Client to0Client = new OwnerTo0Client(new CryptoService(), ds,
+          new OwnerKeyResolver(sc.getInitParameter(OwnerAppConstants.OWNER_KEYSTORE_PWD)),
+              guid, to0Util);
+      to0Client.setRvBlob(sc.getInitParameter(OwnerAppConstants.TO0_RV_BLOB));
+      to0Client.run();
+    } catch (IOException | NoSuchAlgorithmException | InterruptedException e) {
+      sc.log("Error during TO0 for GUID: " + guid.toString());
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
@@ -58,6 +58,10 @@ public class OwnerServerApp {
         OwnerConfigLoader.loadConfig(OwnerAppConstants.OWNER_KEYSTORE_PWD));
     ctx.addParameter(OwnerAppConstants.TO0_SCHEDULING_ENABLED,
         OwnerConfigLoader.loadConfig(OwnerAppConstants.TO0_SCHEDULING_ENABLED));
+    ctx.addParameter(OwnerAppConstants.TO0_SCHEDULING_INTREVAL,
+        OwnerConfigLoader.loadConfig(OwnerAppConstants.TO0_SCHEDULING_INTREVAL));
+    ctx.addParameter(OwnerAppConstants.TO0_RV_BLOB,
+        OwnerConfigLoader.loadConfig(OwnerAppConstants.TO0_RV_BLOB));
     ctx.addApplicationListener(DbStarter.class.getName());
     ctx.addApplicationListener(OwnerContextListener.class.getName());
     ctx.setParentClassLoader(ctx.getClass().getClassLoader());

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerTo0Client.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerTo0Client.java
@@ -5,10 +5,9 @@ package org.fido.iot.sample;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.util.List;
-import org.fido.iot.certutils.PemLoader;
+import java.util.UUID;
+import javax.sql.DataSource;
 import org.fido.iot.protocol.Composite;
 import org.fido.iot.protocol.Const;
 import org.fido.iot.protocol.CryptoService;
@@ -20,163 +19,104 @@ import org.fido.iot.protocol.RendezvousBlobDecoder;
 import org.fido.iot.protocol.RendezvousInfoDecoder;
 import org.fido.iot.protocol.To0ClientService;
 import org.fido.iot.protocol.To0ClientStorage;
-import org.fido.iot.sample.WebClient;
+import org.fido.iot.storage.OwnerDbTo0Storage;
+import org.fido.iot.storage.OwnerDbTo0Util;
 
 public class OwnerTo0Client {
-  
-  private static final String RV_BLOB = "http://localhost:8042?ipaddress=127.0.0.1";
-  
-  private static final String VOUCHER = ""
-      + "8486186450f0956089c0df4c349c61f460457e87eb81858205696c6f63616c686f73748203191f68820c01820"
-      + "2447f0000018204191f686a44656d6f446576696365830d0258402c02709032b3fc1696ab55b1ecf8e44795b9"
-      + "2cb21b6a681265e54d525c8533fb74b0c0310166ef11b0f32aef76e135f86acdd65633267de932b31df43e50c"
-      + "62582085820744c9e7af744e7408e288d27017d0904605eed5bc07e7c1771404e569bdfe3e6820558205cd7dd"
-      + "9fd13c8f681dc42208f4770ccbe10b6beb178cb595bacd53bc3f61e3b18259017a308201763082011d0209008"
-      + "da355b7e71c51f5300a06082a8648ce3d040302300d310b300906035504030c0243413020170d313931313232"
-      + "3135353430315a180f32303534313131333135353430315a3078310b3009060355040613025553310f300d060"
-      + "35504080c064f7265676f6e3112301006035504070c0948696c6c73626f726f310e300c060355040a0c05496e"
-      + "74656c311d301b060355040b0c14446576696365204d616e75666163747572696e673115301306035504030c0"
-      + "c44656d6f44657669636532373059301306072a8648ce3d020106082a8648ce3d03010703420004a582f072ec"
-      + "6a4746d8e7c974558a6c4ec694ce91420a978dddb995d201e9e712c7330bc1151c8eb656313745dac7c7040ec"
-      + "7ef22e549621632b5b3863e467c98300a06082a8648ce3d040302034700304402204386077f39aee794f7e48e"
-      + "af04ff4c18822a8c306994ad4ad75ccab5aef7478c022073ce183429452662c29d4c4d1b750f63167e85c9cb0"
-      + "ef7b2581a986ec9282bf1590126308201223081c9a003020102020900a4d303ae980f53f1300a06082a8648ce"
-      + "3d040302300d310b300906035504030c0243413020170d3139303432343134343634375a180f3230353430343"
-      + "1353134343634375a300d310b300906035504030c0243413059301306072a8648ce3d020106082a8648ce3d03"
-      + "0107034200042c02709032b3fc1696ab55b1ecf8e44795b92cb21b6a681265e54d525c8533fb74b0c0310166e"
-      + "f11b0f32aef76e135f86acdd65633267de932b31df43e50c625a310300e300c0603551d13040530030101ff30"
-      + "0a06082a8648ce3d0403020348003045022100a5419b823613d24eb701e440b4f3368be5675ba72461a272bc5"
-      + "2eeb96c3e414002204e70d27b631cb6efc26aa0c027e1e53eaef1ec5074203683d1ecbb9de129c6928184a101"
-      + "2640588e838208582099713d28d33bb5fa29f77f0da8ff182e5a076670a4ec23244ed504ec6f10fd0f8208582"
-      + "082d4659e9dbbc7fac58ad015faf42ac0947ee511d752ab37edc42eb0d969df28830d025840595504d86d062f"
-      + "2f2c72600ec90ca1701885fdf4947778bf3a0ed70d286225bd88b1b099491aadd5e935e486de088e73ec11de6"
-      + "b61991a068aeb77320f5e603458473045022022acd405ca7c95e8104093becea5d5ddfb25adb55012a1cc7169"
-      + "ccd114977ff50221009e9cdd0815358d35d543bae8362f02ddced995ab1ff96115d423c76313ccea2c";
-  
-  private CryptoService cryptoService;
-  private KeyResolver keyResolver;
-  private Long responseWait = null;
-  
-  public OwnerTo0Client(CryptoService cryptoService, KeyResolver keyResolver) {
+
+  private final CryptoService cryptoService;
+  private final DataSource dataSource;
+  private final KeyResolver keyResolver;
+  private final OwnerDbTo0Util to0Util;
+  private To0ClientStorage clientStorage;
+  private To0ClientService clientService;
+  private UUID guid;
+  private String rvBlob;
+
+  /**
+   * Constructor.
+   */
+  public OwnerTo0Client(CryptoService cryptoService, DataSource dataSource, KeyResolver keyResolver,
+      UUID guid, OwnerDbTo0Util to0Util) {
     this.cryptoService = cryptoService;
+    this.dataSource = dataSource;
     this.keyResolver = keyResolver;
+    this.guid = guid;
+    this.to0Util = to0Util;
   }
-  
-  To0ClientStorage clientStorage = new To0ClientStorage() {
 
-    private String clientToken;
+  public void setRvBlob(String rvBlob) {
+    this.rvBlob = rvBlob;
+  }
 
-    @Override
-    public Composite getVoucher() {
-      return Composite.fromObject(VOUCHER);
+  private To0ClientStorage clientStorage() {
+    if (clientStorage == null) {
+      clientStorage = new OwnerDbTo0Storage(dataSource, keyResolver, guid) {
+
+        @Override
+        public Composite getRedirectBlob() {
+          return RendezvousBlobDecoder.decode(rvBlob);
+        }
+      };
     }
+    return clientStorage;
+  }
 
-    @Override
-    public Composite getRedirectBlob() {
-      return RendezvousBlobDecoder.decode(RV_BLOB);
+  private To0ClientService clientService() {
+    if (clientService == null) {
+      clientService = new To0ClientService() {
+
+        @Override
+        protected To0ClientStorage getStorage() {
+          return clientStorage();
+        }
+
+        @Override
+        public CryptoService getCryptoService() {
+          return cryptoService;
+        }
+      };
     }
+    return clientService;
+  }
 
-    @Override
-    public long getRequestWait() {
-      return OwnerAppConstants.TO0_REQUEST_WS;
-    }
-
-    @Override
-    public void setResponseWait(long wait) {
-      responseWait = wait;
-      System.out.println("To0 Response Wait: " + Long.toString(wait));
-    }
-
-    @Override
-    public PrivateKey getOwnerSigningKey(PublicKey ownerPublicKey) {
-      return keyResolver.getKey(ownerPublicKey);
-    }
-
-    @Override
-    public void starting(Composite request, Composite reply) {
-
-    }
-
-    @Override
-    public void started(Composite request, Composite reply) {
-
-    }
-
-    @Override
-    public void continuing(Composite request, Composite reply) {
-      Composite info = request.getAsComposite(Const.SM_PROTOCOL_INFO);
-      if (info.containsKey(Const.PI_TOKEN)) {
-        clientToken = info.getAsString(Const.PI_TOKEN);
-      }
-      reply.set(Const.SM_PROTOCOL_INFO, Composite.newMap().set(Const.PI_TOKEN, clientToken));
-    }
-
-    @Override
-    public void continued(Composite request, Composite reply) {
-
-    }
-
-    @Override
-    public void completed(Composite request, Composite reply) {
-
-    }
-
-    @Override
-    public void failed(Composite request, Composite reply) {
-
-    }
-  };
-  
-  To0ClientService clientService = new To0ClientService() {
-
-    @Override
-    protected To0ClientStorage getStorage() {
-      return clientStorage;
-    }
-
-    @Override
-    public CryptoService getCryptoService() {
-      return cryptoService;
-    }
-  };
-  
   private MessageDispatcher createDispatcher() {
-    
+
     return new MessageDispatcher() {
-      
+
       @Override
       protected MessagingService getMessagingService(Composite request) {
-        return clientService;
+        return clientService();
       }
-      
+
       @Override
       protected void failed(Exception e) {
         e.printStackTrace();
       }
     };
   }
-  
+
   /**
    * Initiates TO0 for a device.
    */
   public void run() throws NoSuchAlgorithmException, IOException, InterruptedException {
-    
+    System.out.println("TO0 Client started for GUID " + guid.toString());
     MessageDispatcher dispatcher = createDispatcher();
-    
-    DispatchResult dr = clientService.getHelloMessage();
-    
-    Composite ovh = clientStorage.getVoucher().getAsComposite(Const.OV_HEADER);
+
+    DispatchResult dr = clientService().getHelloMessage();
+
+    Composite ovh = clientStorage().getVoucher().getAsComposite(Const.OV_HEADER);
     Composite rvi = ovh.getAsComposite(Const.OVH_RENDEZVOUS_INFO);
-    
+
     List<String> paths = RendezvousInfoDecoder.getHttpDirectives(rvi, Const.RV_OWNER_ONLY);
-    
+
     for (String path : paths) {
-      
-      responseWait = null;
+
       try {
         WebClient client = new WebClient(path, dr, dispatcher);
         client.run();
-        if (responseWait != null) {
+        long responseWait = this.to0Util.getResponseWait(dataSource, guid);
+        if (responseWait > 0) {
           break;
         }
       } catch (Exception e) {
@@ -184,6 +124,6 @@ public class OwnerTo0Client {
         throw e;
       }
     }
-    System.out.println("TO0 Client finished.");
+    System.out.println("TO0 Client finished for GUID " + guid.toString());
   }
 }

--- a/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbTo0Storage.java
+++ b/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbTo0Storage.java
@@ -1,0 +1,171 @@
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package org.fido.iot.storage;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.fido.iot.protocol.Composite;
+import org.fido.iot.protocol.Const;
+import org.fido.iot.protocol.KeyResolver;
+import org.fido.iot.protocol.To0ClientStorage;
+
+public class OwnerDbTo0Storage implements To0ClientStorage {
+
+  private DataSource dataSource;
+  private KeyResolver keyResolver;
+  private Composite voucher;
+  private UUID guid;
+  private String clientToken;
+
+  // default TO0 waitseconds
+  public static final int TO0_REQUEST_WS = 3600;
+
+  /**
+   * Constructor.
+   * 
+   * @param dataSource A SQL datasource
+   * @param keyResolver Instance of {@link KeyResolver}
+   * @param guid {@link UUID} of the device the storage will serve
+   */
+  public OwnerDbTo0Storage(DataSource dataSource, KeyResolver keyResolver, UUID guid) {
+    this.dataSource = dataSource;
+    this.keyResolver = keyResolver;
+    this.guid = guid;
+  }
+
+  @Override
+  public Composite getVoucher() {
+    String sql = "SELECT VOUCHER FROM TO2_DEVICES WHERE GUID = ?;";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      pstmt.setString(1, guid.toString());
+      try (ResultSet rs = pstmt.executeQuery()) {
+        while (rs.next()) {
+          voucher = Composite.fromObject(rs.getBinaryStream(1));
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    return voucher;
+  }
+
+  @Override
+  public Composite getRedirectBlob() {
+    return voucher.getAsComposite(Const.OV_HEADER).getAsComposite(Const.OVH_RENDEZVOUS_INFO);
+  }
+
+  @Override
+  public long getRequestWait() {
+    String sql = "SELECT WAIT_SECONDS_REQUEST FROM TO2_DEVICES WHERE GUID = ?;";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      pstmt.setString(1, guid.toString());
+      try (ResultSet rs = pstmt.executeQuery()) {
+        while (rs.next()) {
+          return rs.getInt(1);
+        }
+      }
+    } catch (SQLException e) {
+      System.out.println(e.getMessage());
+    }
+    // return default value
+    return TO0_REQUEST_WS;
+  }
+
+  @Override
+  public void setResponseWait(long wait) {
+    String sql = "UPDATE TO2_DEVICES SET WAIT_SECONDS_RESPONSE = ? WHERE GUID = ?";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      pstmt.setInt(1, (int) wait);
+      pstmt.setString(2, guid.toString());
+
+      pstmt.executeUpdate();
+
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    System.out.println("To0 Response Wait for " + guid.toString() + " : " + Long.toString(wait));
+  }
+
+  @Override
+  public PrivateKey getOwnerSigningKey(PublicKey ownerPublicKey) {
+    return keyResolver.getKey(ownerPublicKey);
+  }
+
+  @Override
+  public void starting(Composite request, Composite reply) {
+
+  }
+
+  @Override
+  public void started(Composite request, Composite reply) {
+    String sql = "UPDATE TO2_DEVICES SET TO0_STARTED = ? WHERE GUID = ?";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      Timestamp created = new Timestamp(Calendar.getInstance().getTimeInMillis());
+      pstmt.setTimestamp(1, created);
+      pstmt.setString(2, guid.toString());
+
+      pstmt.executeUpdate();
+
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void continuing(Composite request, Composite reply) {
+    Composite info = request.getAsComposite(Const.SM_PROTOCOL_INFO);
+    if (info.containsKey(Const.PI_TOKEN)) {
+      clientToken = info.getAsString(Const.PI_TOKEN);
+    }
+    reply.set(Const.SM_PROTOCOL_INFO, Composite.newMap().set(Const.PI_TOKEN, clientToken));
+  }
+
+  @Override
+  public void continued(Composite request, Composite reply) {
+
+  }
+
+  @Override
+  public void completed(Composite request, Composite reply) {
+    String sql = "UPDATE TO2_DEVICES SET TO0_COMPLETED = ? WHERE GUID = ?";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      Timestamp created = new Timestamp(Calendar.getInstance().getTimeInMillis());
+      pstmt.setTimestamp(1, created);
+      pstmt.setString(2, guid.toString());
+
+      pstmt.executeUpdate();
+
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void failed(Composite request, Composite reply) {
+
+  }
+}

--- a/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbTo0Util.java
+++ b/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbTo0Util.java
@@ -1,0 +1,67 @@
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package org.fido.iot.storage;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+
+public class OwnerDbTo0Util {
+
+  /**
+   * Return {@link List} of {@link UUID} whose TO0 is either not done, or has expired.
+   *
+   * @param dataSource A SQL datasource
+   * @return
+   */
+  public List<UUID> fetchDevicesForTo0(DataSource dataSource) {
+    String sql = "SELECT GUID FROM TO2_DEVICES WHERE WAIT_SECONDS_RESPONSE = 0 "
+        + "OR TO0_COMPLETED IS NULL "
+        + "OR TIMESTAMPADD(SECOND, WAIT_SECONDS_RESPONSE, TO0_COMPLETED) <  CURRENT_TIMESTAMP();";
+
+    List<UUID> uuids = new LinkedList<UUID>();
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      try (ResultSet rs = pstmt.executeQuery()) {
+        while (rs.next()) {
+          uuids.add(UUID.fromString(rs.getString(1)));
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    return uuids;
+  }
+
+  /**
+   * Return the stored wait seconds as sent by Rendezvous during TO0 for the device.
+   * 
+   * @param dataSource A SQL datasource
+   * @param guid Device guid
+   * @return
+   */
+  public long getResponseWait(DataSource dataSource, UUID guid) {
+    String sql = "SELECT WAIT_SECONDS_RESPONSE FROM TO2_DEVICES WHERE GUID = ?;";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      pstmt.setString(1, guid.toString());
+      try (ResultSet rs = pstmt.executeQuery()) {
+        while (rs.next()) {
+          return rs.getInt(1);
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    return 0;
+  }
+}


### PR DESCRIPTION
- Eligible devices for TO0 (based on their stored TO0 wait seconds) are
scheduled on a separate thread, managed by ExecutorService.
- Moved To0ClientStorage impl to Owner storage and updated TO0Client
appropriately.
- Added few configurable properties to manage scheduling TO0 and removed
few hard-coded values from TO0Client.
Additionally, fixed whitespacing issues at places.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>