### PR TITLE
Adding epid url config property at component samples

### DIFF
--- a/demo/owner/owner.env
+++ b/demo/owner/owner.env
@@ -3,6 +3,7 @@ owner_database_connection_url=jdbc:h2:tcp://localhost:8051/./target/data/ops
 owner_database_username=sa
 owner_database_password=
 owner_database_port=8051
+#epid_online_url=https://verify.epid-sbx.trustedservices.intel.com/
 catalina_home=./target/tomcat
 owner_keystore_password=OnrKstr1
 owner_to0_scheduling_enabled=false

--- a/demo/rv/rv.env
+++ b/demo/rv/rv.env
@@ -3,4 +3,5 @@ rv_database_connection_url=jdbc:h2:tcp://localhost:8050/./target/data/rvs
 rv_database_username=sa
 rv_database_password=
 rv_database_port=8050
+#epid_online_url=https://verify.epid-sbx.trustedservices.intel.com/
 catalina_home=./target/tomcat

--- a/protocol/src/main/java/org/fido/iot/protocol/epid/EpidUtils.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/epid/EpidUtils.java
@@ -41,6 +41,7 @@ public class EpidUtils {
       throw new IllegalArgumentException();
     }
     epidOnlineUrl = URI.create(url);
+    System.out.println("EPID Online URL: " + epidOnlineUrl.toString());
   }
 
   /**

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerAppConstants.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerAppConstants.java
@@ -22,6 +22,9 @@ public class OwnerAppConstants {
   // tomcat's catalaina.home
   public static final String SERVER_PATH = "catalina_home";
   
+  // EPID URL
+  public static final String EPID_URL = "epid_online_url";
+
   // the user pin for HSM keystore that contains the owner keys
   public static final String OWNER_KEYSTORE_PWD = "owner_keystore_password";
   

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerConfigLoader.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerConfigLoader.java
@@ -48,9 +48,10 @@ public class OwnerConfigLoader {
       return systemConfiguration.interpolatedConfiguration().getString(property);
     } else if (environmentConfiguration.containsKey(property)) {
       return environmentConfiguration.getString(property);
-    } else if (fileBasedConfiguration.containsKey(property)) {
+    } else if (null != fileBasedConfiguration && fileBasedConfiguration.containsKey(property)) {
       return fileBasedConfiguration.getString(property);
     }
-    throw new RuntimeException();
+    System.out.println("Could not load property: " + property);
+    return null;
   }
 }

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerContextListener.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerContextListener.java
@@ -35,6 +35,7 @@ import org.fido.iot.protocol.MessageDispatcher;
 import org.fido.iot.protocol.MessagingService;
 import org.fido.iot.protocol.To2ServerService;
 import org.fido.iot.protocol.To2ServerStorage;
+import org.fido.iot.protocol.epid.EpidUtils;
 import org.fido.iot.storage.OwnerDbManager;
 import org.fido.iot.storage.OwnerDbStorage;
 
@@ -122,6 +123,10 @@ public class OwnerContextListener implements ServletContextListener {
       }
     };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);
+    String epidUrl = sc.getInitParameter(OwnerAppConstants.EPID_URL);
+    if (null != epidUrl) {
+      EpidUtils.setEpidOnlineUrl(epidUrl);
+    }
     // create tables
     OwnerDbManager manager = new OwnerDbManager();
     manager.createTables(ds);

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
@@ -53,7 +53,11 @@ public class OwnerServerApp {
         + OwnerConfigLoader.loadConfig(OwnerAppConstants.DB_PORT));
     ctx.addParameter("webAllowOthers", "true");
     ctx.addParameter("trace", "");
-    
+
+    if (null != OwnerConfigLoader.loadConfig(OwnerAppConstants.EPID_URL)) {
+      ctx.addParameter(OwnerAppConstants.EPID_URL,
+          OwnerConfigLoader.loadConfig(OwnerAppConstants.EPID_URL));
+    }
     ctx.addParameter(OwnerAppConstants.OWNER_KEYSTORE_PWD,
         OwnerConfigLoader.loadConfig(OwnerAppConstants.OWNER_KEYSTORE_PWD));
     ctx.addParameter(OwnerAppConstants.TO0_SCHEDULING_ENABLED,

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvAppSettings.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvAppSettings.java
@@ -17,4 +17,7 @@ public class RvAppSettings {
 
   // tomcat's catalaina.home
   public static final String SERVER_PATH = "catalina_home";
+
+  // EPID URL
+  public static final String EPID_URL = "epid_online_url";
 }

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvConfigLoader.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvConfigLoader.java
@@ -48,9 +48,10 @@ public class RvConfigLoader {
       return systemConfiguration.interpolatedConfiguration().getString(property);
     } else if (environmentConfiguration.containsKey(property)) {
       return environmentConfiguration.getString(property);
-    } else if (fileBasedConfiguration.containsKey(property)) {
+    } else if (null != fileBasedConfiguration && fileBasedConfiguration.containsKey(property)) {
       return fileBasedConfiguration.getString(property);
     }
-    throw new RuntimeException();
+    System.out.println("Could not load property: " + property);
+    return null;
   }
 }

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvContextListener.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvContextListener.java
@@ -20,6 +20,7 @@ import org.fido.iot.protocol.To0ServerService;
 import org.fido.iot.protocol.To0ServerStorage;
 import org.fido.iot.protocol.To1ServerService;
 import org.fido.iot.protocol.To1ServerStorage;
+import org.fido.iot.protocol.epid.EpidUtils;
 import org.fido.iot.storage.RvsDbManager;
 import org.fido.iot.storage.To0AllowListDenyListDbStorage;
 import org.fido.iot.storage.To1DbStorage;
@@ -84,6 +85,10 @@ public class RvContextListener implements ServletContextListener {
           }
         };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);
+    String epidUrl = sc.getInitParameter(RvAppSettings.EPID_URL);
+    if (null != epidUrl) {
+      EpidUtils.setEpidOnlineUrl(epidUrl);
+    }
     // create tables
     RvsDbManager manager = new RvsDbManager();
     manager.createTables(ds);

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
@@ -45,6 +45,9 @@ public class RvServerApp {
 
     ctx.addParameter("webAllowOthers", "true");
     ctx.addParameter("trace", "");
+    if (null != RvConfigLoader.loadConfig(RvAppSettings.EPID_URL)) {
+      ctx.addParameter(RvAppSettings.EPID_URL, RvConfigLoader.loadConfig(RvAppSettings.EPID_URL));
+    }
 
     ctx.addApplicationListener(DbStarter.class.getName());
     ctx.addApplicationListener(RvContextListener.class.getName());


### PR DESCRIPTION
- Added EPID URL config property to Component sample Owner and Rv apps.
- Additonally, updating config loaders to return null instead of
throwing exception, in case property is not found.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>