### PR TITLE
Resolving klocwork issues

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/epid/EpidSignatureVerifier.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/epid/EpidSignatureVerifier.java
@@ -69,7 +69,7 @@ public class EpidSignatureVerifier {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(groupId);
     baos.write(ByteBuffer.allocate(2).order(ByteOrder.BIG_ENDIAN)
-        .putShort((short) signedPayload.length).array());
+        .putShort((short) (signedPayload != null ? signedPayload.length : 0)).array());
     baos.write(signedPayload);
     baos.write(ByteBuffer.allocate(2).order(ByteOrder.BIG_ENDIAN).putShort((short) 0).array());
     baos.write(signature);

--- a/protocol/src/main/java/org/fido/iot/protocol/epid/EpidSignatureVerifier.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/epid/EpidSignatureVerifier.java
@@ -69,7 +69,7 @@ public class EpidSignatureVerifier {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(groupId);
     baos.write(ByteBuffer.allocate(2).order(ByteOrder.BIG_ENDIAN)
-        .putShort((short) (signedPayload != null ? signedPayload.length : 0)).array());
+        .putShort((short) signedPayload.length).array());
     baos.write(signedPayload);
     baos.write(ByteBuffer.allocate(2).order(ByteOrder.BIG_ENDIAN).putShort((short) 0).array());
     baos.write(signature);

--- a/service/component-samples/http-device-sample/src/main/java/org/fido/iot/sample/Device.java
+++ b/service/component-samples/http-device-sample/src/main/java/org/fido/iot/sample/Device.java
@@ -377,8 +377,9 @@ public class Device {
     try {
       Composite credentials = myCredStore.load();
       logger.info("credentials loaded, GUID is " + credentials.getAsUuid(Const.DC_GUID));
-      doTransferOwnership(credentials);
-
+      if (credentials != null) {
+        doTransferOwnership(credentials);
+      }
     } catch (IOException e) {
       doDeviceInit();
     }

--- a/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerConfigLoader.java
+++ b/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerConfigLoader.java
@@ -35,6 +35,7 @@ public class ManufacturerConfigLoader {
         throw new ConfigurationException();
       }
     } catch (ConfigurationException e) {
+      System.out.println("The Manufacturer application might not be using config file");
       // ignore the error since the application might not be using config file.
       // log when logging is enabled in the application.
     }

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerConfigLoader.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerConfigLoader.java
@@ -32,6 +32,7 @@ public class OwnerConfigLoader {
         throw new ConfigurationException();
       }
     } catch (ConfigurationException e) {
+      System.out.println("The Owner application might not be using config file");
       // ignore the error since the application might not be using config file.
       // log when logging is enabled in the application.
     }

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvConfigLoader.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvConfigLoader.java
@@ -32,6 +32,7 @@ public class RvConfigLoader {
         throw new ConfigurationException();
       }
     } catch (ConfigurationException e) {
+      System.out.println("The RV application might not be using config file");
       // ignore the error since the application might not be using config file.
       // log when logging is enabled in the application.
     }

--- a/storage/storage-samples/storage-di-sample/src/main/java/org/fido/iot/storage/DiDbStorage.java
+++ b/storage/storage-samples/storage-di-sample/src/main/java/org/fido/iot/storage/DiDbStorage.java
@@ -250,7 +250,6 @@ public class DiDbStorage implements DiServerStorage {
 
       final X509EncodedKeySpec subjectKeySpec =
           new X509EncodedKeySpec(csr.getSubjectPublicKeyInfo().getEncoded());
-      final PublicKey subjectPublicKey = keyFactory.generatePublic(subjectKeySpec);
 
       final Certificate issuerCert = issuerChain[0];
 
@@ -288,8 +287,8 @@ public class DiDbStorage implements DiServerStorage {
       getCryptoService().verify(chain);
       return chain;
 
-    } catch (NoSuchAlgorithmException | IOException | InvalidKeySpecException
-        | OperatorCreationException | CertificateEncodingException e) {
+    } catch (NoSuchAlgorithmException | IOException | OperatorCreationException
+        | CertificateEncodingException e) {
       throw new DispatchException(e);
     } catch (CertificateException e) {
       throw new DispatchException(e);


### PR DESCRIPTION
 1. In DiDbStorage.java, removing the unused variable **'SubjectPublicKey'**

 2. In EpidSignatureVerifer.java, **Adding null check on 'signedPayload'** to
    avoid dereferencing which may result in nullpointer exception.

 3. In Device.java, **Adding null check on 'credentials'** to
    avoid dereferencing which may result in nullpointer exception.

 4. In Owner,RV,ManufacturerConfigLoader.java, **resolving the empty catch
    clause** issue by printing an error message.

Signed-off-by: Davis Benny <davis.benny@intel.com>