### PR TITLE
Fix for HTTP Device Component sample.

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
@@ -441,7 +441,7 @@ public class CryptoService {
    * @return signature
    */
   public Composite getSigInfoB(Composite sigInfoA) {
-    if (null != sigInfoA
+    if (null != sigInfoA && sigInfoA.size() > 0
             && Arrays.asList(Const.SG_EPIDv10, Const.SG_EPIDv11, Const.SG_EPIDv20)
             .contains(sigInfoA.getAsNumber(Const.FIRST_KEY).intValue())) {
       EpidMaterialService epidMaterialService = new EpidMaterialService();
@@ -609,7 +609,8 @@ public class CryptoService {
    * @return True if the signature matches otherwise false.
    */
   public boolean verify(PublicKey verificationKey, Composite cose, Composite sigInfoA) {
-    if (null != sigInfoA && Arrays.asList(Const.SG_EPIDv10, Const.SG_EPIDv11, Const.SG_EPIDv20)
+    if (null != sigInfoA && sigInfoA.size() > 0
+        && Arrays.asList(Const.SG_EPIDv10, Const.SG_EPIDv11, Const.SG_EPIDv20)
         .contains(sigInfoA.getAsNumber(Const.FIRST_KEY).intValue())) {
       verifyMaroePrefix(cose);
       return EpidSignatureVerifier.verify(cose, sigInfoA);

--- a/service/component-samples/http-device-sample/pom.xml
+++ b/service/component-samples/http-device-sample/pom.xml
@@ -193,9 +193,15 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${project-demo-directory}/${project.artifactId}</directory>
+              <directory>${project-demo-directory}/${project.artifactId}/lib</directory>
               <includes>
                 <include>**</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>${project-demo-directory}/${project.artifactId}</directory>
+              <includes>
+                <include>device.jar</include>
               </includes>
             </fileset>
           </filesets>


### PR DESCRIPTION
- Updated cryptoservice to handle empty composite object
sent by HTTP device component sample for 'eA' field for
non-EPID devices.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>