### PR TITLE
README Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 For the instructions in this document, `<fido-iot-src>` refers to the path of the FIDO
 IoT source folder 'pri'.
 
-FIDO IoT source code is organized into following sub-folders.
+FIDO IoT source code is organized into the following sub-folders.
 
 - `cert-utils`: It contains utilities for loading certificates and keys from PEM formatted strings.
 
@@ -22,15 +22,15 @@ FIDO IoT source code is organized into following sub-folders.
 ## Building FIDO IoT source
 
 FIDO IoT source is written in [Java 11](https://openjdk.java.net/projects/jdk/11/) and uses the
-[Apache Maven* software](http://maven.apache.org). The instructions which follow describe a simple
+[Apache Maven* software](http://maven.apache.org). The instructions which follow describes a simple
 build and assume familiarity with
 [the Maven build lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html).
 
-Following ports are used for unit-tests and sample code - 8039, 8040, 8042, 8043, 8049, 8050 and 8051.
+Following ports are used for unit-tests and sample code - 8039, 8040, 8042, 8043, 8049, 8050, and 8051.
 Ensure that these ports are not used by other applications while building and executing the
 binaries.
 
-Use following commands to build FIDO IoT source.
+Use the following commands to build FIDO IoT source.
 ```
 $ cd <fido-iot-src>
 $ mvn clean install
@@ -68,7 +68,7 @@ $ mvn exec:java
 
 The server will listen for FIDO IoT HTTP messages on port 8039.
 The H2 database will listen on TCP port 8049.
-You can allow remote database console connections by setting webAllowOthers=true in the .h2.server.properties file located your user home directory (e.g '~' for Linux and C:\Users\[username] for Windows).
+You can allow remote database console connections by setting webAllowOthers=true in the .h2.server.properties file located your user home directory (for example, '~' for Linux and C:\Users\[username] for Windows).
 
 ### Running FIDO IoT HTTP Clients
 
@@ -116,7 +116,7 @@ The DI server will listen for messages at http://localhost:8039/fido/100/msg/<ms
 The server also includes an SQL database that runs on port 8049. The database console
 UI will be available at http://localhost:8039/console.
 
-Extended ownership vouchers can be obtained from the following uri:
+Extended ownership vouchers can be obtained from the following url:
 
 http://localhost:8039/api/v1/vouchers/<serial_no>
 ***NOTE***: Default serial number is '0'. To get the serial_no corresponding to the GUID, look up the `SERIAL_NO` field of MT_DEVICES table in the DI database.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can allow remote database console connections by setting webAllowOthers=true
 
 #### Running the FIDO IoT Device Initialization (DI) HTTP client
 ```
-$ cd <fido-iot-src>/service/http-client-samples/http-client-di-sample
+$ cd <fido-iot-src>/service/protocol-samples/http-client-di-sample
 $ mvn exec:java
 ```
 
@@ -86,7 +86,7 @@ Refer [Ownership Voucher Creation](#ownership-voucher-creation) for next steps.
 
 #### Running the FIDO IoT To0 HTTP client
 ```
-$ cd <fido-iot-src>/service/http-client-samples/http-client-to0-sample
+$ cd <fido-iot-src>/service/protocol-samples/http-client-to0-sample
 $ mvn exec:java
 ```
 
@@ -95,7 +95,7 @@ TO0 Client finished.
 
 #### Running the FIDO IoT To1 HTTP client
 ```
-$ cd <fido-iot-src>/service/http-client-samples/http-client-to1-sample
+$ cd <fido-iot-src>/service/protocol-samples/http-client-to1-sample
 $ mvn exec:java
 ```
 
@@ -104,7 +104,7 @@ TO1 Client finished.
 
 ### Running the FIDO IoT To2 HTTP client
 ```
-$ cd <fido-iot-src>/service/http-client-samples/http-client-to2-sample
+$ cd <fido-iot-src>/service/protocol-samples/http-client-to2-sample
 $ mvn exec:java
 ```
 
@@ -127,7 +127,7 @@ To log in to the database and view records use the following information:
 ```
 "User Name:" = "sa"
 "Password:" = "" (blank)
-"JDBC URL:" = "jdbc:h2:tcp://<localhost>:8049/<fido-iot-src>/service/http-server-samples/http-server-di-sample/target/data/mfg"
+"JDBC URL:" = "jdbc:h2:tcp://<localhost>:8049/<fido-iot-src>/service/protocol-samples/http-server-di-sample/target/data/mfg"
 ```
 The path to the DB will be printed out in following format when the DI server is starting.
 
@@ -135,483 +135,25 @@ The path to the DB will be printed out in following format when the DI server is
 
 SELECT * FROM MT_DEVICES will show the current vouchers created by DI messages.
 
+# Enabling Remote Access to DB
+
+Remote access to H2 Sample Storage DB has been disabled by default. Enabling the access creates a security hole in the system which makes it vulnerable to Remote Code Execution.
+
+To enable remote access to DB update the `db.tcpServer` and `webAllowOthers` properties in the following files:
+
+- To enable remote access for DI server DB, update file:  `<fido-iot-src>/service/protocol-samples/http-server-di-sample/src/main/java/org/fido/iot/sample/DiApp.java` <br/>
+
+- To enable remote access for TO0-TO1 server DB, update file:  `<fido-iot-src>/service/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fido/iot/sample/To0To1ServerApp.java` <br/>
+
+- To enable remote access for TO2 server DB, update file:  `<fido-iot-src>/service/protocol-samples/http-server-to2-sample/src/main/java/org/fido/iot/sample/To2ServerApp.java`
+
+```
+db.tcpServer = -tcp -tcpAllowOthers -ifNotExists -tcpPort <service_db_port>
+webAllowOthers = true
+```
+
+**IMPORTANT: NOT recommended to use enable this setting especially on production systems.**
+
 ## Using Component Samples
 
-### Setup Keystore using SoftHSM
-
-- Install the following dependencies:
-
-  ```
-  $ sudo apt-get install libsofthsm2 softhsm softhsm-common opensc
-  ```
-- Copy <fido-iot-src>/demo/<component-name>/java.security to /etc/java-11-openjdk/security/
-- Copy <fido-iot-src>/demo/<component-name>/pkcs11.cfg to /etc/softhsm/
-
-### Configuring the FIDO IoT Manufacturer Sample
-
-Some required runtime arguments
-
-- `manufacturer_di_port`
-
-  Manufacturer server port.
-
-  Docker default is: 8039.
-
-- `manufacturer_database_connection_url`
-
-   JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file
-
-  Docker default: jdbc:h2:tcp://localhost:8049/./target/data/mfg
-
-- `manufacturer_database_username`
-
-  Manufacturer database username.
-
-  Docker default: sa
-
-- `manufacturer_database_password`
-
-  Manufacturer database password.
-
-  Docker default: <no_password>
-
-- `manufacturer_database_port`
-
-  Manufacturer database port number.
-
-  Docker default: 8049
-
-- `catalina_home`
-
-  Tomcat configuration.
-
-  Docker default: ./target/tomcat
-
-- `manufacturer_keystore_password`
-
-  Keystore password for manufacturer_keystore.p12 and the internal softHSM's PKCS11 keystore.
-
-  Docker default: MfgKs@3er
-
-- `manufacturer_api_user`
-
-  Username for the non-SDO REST API calls.
-
-  Docker default: apiUser
-
-- `manufacturer_api_password`
-
-  Password for the non-SDO REST API calls.
-
-  Docker default: MfgApiPass123
-
-### Running the FIDO IoT Manufacturer Sample
-
-There are two ways of running Manufacturer Component Sample:
-
-1. Using docker
-
-  To execute Manufacturer using docker, refer [Demo Manufacturer README](#https://github.com/secure-device-onboard/pri-fidoiot/tree/master/demo/manufacturer)
-
-2. Command line execution:
-
-```
-$ cd <fido-iot-src>/service/component-samples/manufacturer
-$ mvn -Dmanufacturer_di_port=<manufacturer-server-port> -Dmanufacturer_database_connection_url=<jdbc-url> -Dmanufacturer_database_username=<manufacturer-database-username> -Dmanufacturer_database_password=<manufacturer-database-password> -Dmanufacturer_database_port=<manufacturer-server-database-port> -Dcatalina_home=<path-to-catalina-home> -Dmanufacturer_keystore_password=<manufacturer-keystore-password> -Dmanufacturer_api_user=<manufacturer-api-user> -Dmanufacturer_api_password=<manufacturer-api-password> exec:java
-```
-
-### FIDO IoT Manufacturer REST APIs
-
-| Operation                      | Description                        | Path/Query Parameters    | Content Type   |Request Body  | Response Body |
-| ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|
-| POST /api/v1/assign/?id=<customer_id>&guid=<device_guid> | Assigns customer ID to voucher having the input GUID. | Query - id: Customer ID, guid = Device GUID | | | |
-| GET /api/v1/vouchers/<serial_no> | Gets extended voucher with the serial number. | Path - Device Serial Number | | | Ownership Voucher |
-| POST /api/v1/customers/?id=<customer_id>&name=<customer_name> | Adds customer with the given ID and Public key in PEM format. | Query - id: Customer Id, name: Customer Name | text/plain; charset=us-ascii | Customer PEM formatted Public keys | |
-
-***NOTE*** These REST APIs use Digest authentication. `manufacturer_api_user` and `manufacturer_api_password` properties specify the credentials to be used while making the REST calls.
-
-### Configuring the FIDO IoT Reseller Sample
-
-Some required runtime arguments
-
-- `reseller_api_port`
-
-  Reseller server port.
-
-  Default is: 8070
-
-- `reseller_database_connection_url`
-
-   JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file
-
-  Default: jdbc:h2:tcp://localhost:8071/<path-to-user-dir>
-
-- `reseller_database_username`
-
-  Reseller database username.
-
-  Default: sa
-
-- `reseller_database_password`
-
-  Reseller database password.
-
-  Default: <no-password>
-
-- `reseller_database_port`
-
-  Reseller database port number.
-
-  Default: 8071
-
-- `reseller_database_driver`
-
-  Reseller database driver.
-
-  Default: org.h2.Driver
-
-- `reseller_api_user`
-
-  Reseller API username.
-
-  Default: admin
-
-- `reseller_api_password`
-
-  Reseller API password.
-
-  Default: test
-
-- `reseller_home`
-
-  Tomcat configuration for catalina home.
-
-  Default: catalina.home
-
-- `reseller_keystore_type`
-
-  Reseller keystore type
-
-  Default: PKCS11
-
-- `reseller_keystore_password`
-
-  Reseller keystore password
-
-  Default: 123456
-
-- `user.dir`
-
-  Base path for jdbc `.db` file location.
-
-### Running the FIDO IoT Reseller Sample
-
-There are two ways of running Reseller Component Sample:
-
-1. Using docker
-
-  To execute Reseller using docker, refer [Demo Reseller README](#https://github.com/secure-device-onboard/pri-fidoiot/tree/master/demo/reseller)
-
-2. Command line execution:
-
-  - Refer steps to [setup keystore using softhsm](#setup-keystore-using-softhsm).
-  - Run service using the command:
-    ```
-    $ cd <fido-iot-src>/service/component-samples/reseller
-    $ mvn exec:java
-    ```
-
-### FIDO IoT Reseller REST APIs
-
-| Operation                      | Description                        | Path/Query Parameters    | Content Type   |Request Body  | Response Body |
-| ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|
-| GET /api/v1/resell/vouchers/<serial_number>?id=<customer_id> | Assigns the customer and returns the extended voucher for the given serial number from `RT_DEVICES` table. | Query - id: Customer Id, Path - Device Serial Number | | | Ownership voucher |
-| POST /api/v1/resell/vouchers/<serial_number> | Adds voucher to `RT_DEVICES` table against the serial number. | Path - Device Serial Number | application/cbor | Ownership voucher | |
-| DELETE /api/v1/resell/vouchers/<serial_number> | Deletes voucher from `RT_DEVICES` table with the specified serial number. | Path - Device Serial Number | | | |
-| POST /api/v1/resell/customers/?id=<customer_id>&name=<customer_name> | Adds customer keyset to `RT_CUSTOMERS` table. | Query - id: Customer Id, name: Customer Name | text/plain; charset=us-ascii | Customer PEM formatted Public keys | |
-| POST /api/v1/resell/keys/?alias=<keystore_alias> | Adds new Reseller keys to the keystore with the given alias | Query - alias: Alias to be added in keystore | | PEM formatted certificate and private key | | 
-| DELETE /api/v1/resell/keys/?alias=<keystore_alias> | Deletes the keys corresponding to the input alias from keystore. | Query - alias: Alias to be removed from keystore | | | |
-
-***NOTE*** These REST APIs use Digest authentication. `reseller_api_user` and `reseller_api_password` properties specify the credentials to be used while making the REST calls.
-
-### Configuring the FIDO IoT RV Sample
-
-Some required runtime arguments
-
-- `rv_port`
-
-  RV server port.
-
-  Docker default: 8040
-
-- `rv_database_connection_url`
-
-   JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file
-
-  Docker default: jdbc:h2:tcp://localhost:8050/./target/data/rvs
-
-- `rv_database_username`
-
-  RV database username.
-
-  Docker username: sa
-
-- `rv_database_password`
-
-  RV database password.
-
-  Docker username: <no-password>
-
-- `rv_database_port`
-
-  RV database port number.
-
-  Docker default: 8050
-
-- `epid_online_url`
-
-  EPID Verification Service URL for EPID device signature verification.
-
-  Default: https://verify.epid-sbx.trustedservices.intel.com/
-  Other server options: https://verify.epid.trustedservices.intel.com/ (production EPID verification server), https://localhost:1180 (onprem verification service)
-
-- `catalina_home`
-
-  Tomcat configuration for catalina home.
-
-  Docker default: ./target/tomcat
-
-### Running the FIDO IoT RV Sample
-
-There are two ways of running RV Component Sample:
-
-1. Using docker
-
-  To execute RV using docker, refer [Demo RV README](#https://github.com/secure-device-onboard/pri-fidoiot/tree/master/demo/rv)
-
-2. Command line execution:
-
-```
-$ cd <fido-iot-src>/service/component-samples/rv
-$ mvn -Drv_port=<rv-server-port> -Drv_database_connection_url=<jdbc-url> -Drv_database_username=<rv-database-username> -Drv_database_password=<rv-database-password> -Drv_database_port=<rv-server-database-port> -Depid_online_url=<verification-service-url> -Dcatalina_home=<path-to-cataline-home> exec:java
-```
-
-### Configuring the FIDO IoT Owner Sample
-
-Some required runtime arguments
-
-- `owner_to2_port`
-
-  Owner server port.
-
-  Docker default: 8042
-
-- `owner_database_connection_url`
-
-  JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file.
-
-  Docker default: jdbc:h2:tcp://localhost:8051/./target/data/ops
-
-- `owner_database_username`
-
-  Owner database username.
-
-  Docker default: sa
-
-- `owner_database_password`
-
-  Owner database password.
-
-  Docker default: <no-password>
-
-- `owner_database_port`
-
-  RV database port number.
-
-  Docker default: 8050
-
-- `epid_online_url`
-
-  EPID Verification Service URL for EPID device signature verification.
-
-  Docker Default: https://verify.epid-sbx.trustedservices.intel.com/
-  Other server options: https://verify.epid.trustedservices.intel.com/ (production EPID verification server), https://localhost:1180 (onprem verification service)
-
-- `catalina_home`
-
-  Tomcat configuration for cataline home.
-
-  Docker default: ./target/tomcat
-
-- `owner_keystore_password`
-
-  Keystore password for owner_keystore.p12 and the internal softHSM's PKCS11 keystore.
-
-  Docker default: OnrKstr1
-
-- `owner_to0_scheduling_enabled`
-
-  Auto completes TO0 for GUIDs with DI complete state.
-
-  Docker default: false
-
-- `owner_to0_scheduling_interval`
-
-  Time interval to check database for GUIDs with pending TO0.
-
-  Docker default: 300s
-
-- `owner_to0_rv_blob`
-
-  Information containing network address of prospective owner. Owner shares this information with RV during TO0. RV, then shares the same during TO1. Device, then uses this information to initiate TO2 protocol.
-
-  Docker default: http://localhost:8042?ipaddress=127.0.0.1
-
-- `owner_api_user'
-
-  Username for the non-SDO REST API calls.
-
-  Docker default: apiUser
-
-- `owner_api_password`
-
-  Password for the non-SDO REST API calls.
-
-  Docker default: OwnerApiPass123
-
-- `owner_svi_values`
-
-  Path to the directory that contains default sample owner serviceinfo values. The filenames are used as identifiers in the database, while the actual file content is the requisite serviceinfo that is transferred to the device. Only used for demo purposes and should not be modified.
-
-  Docker default: ./serviceinfo/sample-values
-
-- `owner_svi_string`
-
-  Path to the file that contains default sample svi string that maps serviceinfo values to module names and messages. Only used for demo purposes and should not be modified.
-
-  Docker default: ./serviceinfo/sample-svi.csv
-
-### Running the FIDO IoT Owner Sample
-
-There are two ways of running Owner Component Sample:
-
-1. Using docker
-
-  To execute RV using docker, refer [Demo Owner README](#https://github.com/secure-device-onboard/pri-fidoiot/tree/master/demo/owner)
-
-2. Command line execution:
-
-   - Refer steps to [setup keystore using softhsm](#setup-keystore-using-softhsm).
-   - Run service using the command:
-   ```
-   $ cd <fido-iot-src>/service/component-samples/owner
-   $ mvn -Downer_to2_port=<owner-server-port> -Downer_database_connection_url=<jdbc-url> -Downer_database_username=<owner-database-name> -Downer_database_password=<owner-database-password> -Downer_database_port=<owner-server-database-port> -Depid_online_url=<verification-service-url> -Dcatalina_home=<path-to-catalina-home> -Downer_keystore_password=<owner-keystore-password> -Downer_to0_scheduling_enabled=<true-or-false> -Downer_to0_scheduling_interval=<time-interval-in-ms> -Downer_to0_rv_blob=<owner-url> -Downer_api_user=<owner-api-user> -Downer_api_password=<owner-api-password> -Downer_svi_values=<path-to-owner-svi-values> -Downer_svi_string=<path-to-owner-svi-string> exec:java
-   ```
-
-### FIDO IoT Owner REST APIs
-
-| Operation                      | Description                        | Path/Query Parameters    | Content Type   |Request Body  | Response Body |
-| ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|
-| GET /api/v1/owner/vouchers/    | Returns all voucher available in `TO2_DEVICES` table. | | | | Comma-separated list of GUIDs |
-| GET /api/v1/owner/vouchers/?id=<device_guid> | Returns the voucher for the specified GUID. | Query - id: Device GUID | | | Ownership voucher |
-| POST /api/v1/owner/vouchers/ | Insert voucher against the specified GUID in `TO2_DEVICES` table. | | application/cbor | Content of Ownership voucher in binary format | |
-| DELETE /api/v1/owner/vouchers/?id=<device_guid> | Deletes voucher of the specified GUID from the `TO2_DEVICES` table. | Query - id: Device GUID | | | |
-| POST /api/v1/owner/svivalues/?id=\<serviceinfo_id>&isCborEncoded=<boolean_value> | Adds serviceinfo entry to `OWNER_SERVICEINFO` table. The query parameter 'isCborEncoded' should be 'true' for CBOR encoded binary data that will never be split into smaller chunks while transferring to the device (small in length, to be used for CBOR primitives such as boolean, int, array and map), and it should be 'false' (preferably) for other binary data that could be splitted into smaller chunks and transferred across messages (for example binary values, string). | Query - id: Service info ID, isCborEncoded: Boolean | application/octet-stream or application/cbor | Content of Serviceinfo in binary format. | |
-| DELETE /api/v1/owner/svivalues/?id=<serviceinfo_id> | Deletes the serviceinfo values from `OWNER_SERVICEINFO` table. | Query - id: Service info ID | | | |
-| POST /api/v1/owner/svi/?guid=<device_guid> | Adds owner serviceinfo for the GUID in `GUID_OWNERSVI` table, that will be transferred to the device in the insertion order. The format is `Entry1,Entry2,Entry3` and so on, where each Entry contains `moduleName:messageName=serviceInfoId`. Here, the 'content' corresponding to the 'serviceInfoId' is transferred to the device. Please see \<fido-iot-src\>/demo/owner/serviceinfo/sample-svi.csv as an example for the above format, where moduleName is 'sdo_sys' and messageName is either one of 'filedesc', 'write' and 'exec'. The order of each 'Entry' is important as this order decides the sequence in which the Owner will transfer the Service info. | Query - guid: Device GUID | application/text | SVI string | |
-| DELETE /api/v1/owner/svi/?guid=<device_guid> | Deletes owner serviceinfo for the GUID from the `GUID_OWNERSVI` table. | Query - guid: Device GUID | | | |
-
-***NOTE*** These REST APIs use Digest authentication. `owner_api_user` and `owner_api_password` properties specify the credentials to be used while making the REST calls.
-
-### Configuring the FIDO IoT HTTP Java Device Sample
-
-Some software settings are runtime-configurable via Java properties.  They include:
-
-- `fido.iot.randoms`
-
-  A comma-separated list of Java `SecureRandom` algorithm names for random number generation.
-  Values are in order from least to most preferred.
-
-  Default is `"NativePRNG,Windows-PRNG"`.
-
-- `fido.iot.url.di`
-
-  The URL at which the Device Initialization (DI) server may be found.
-
-  Default is `http://localhost:8039/`.
-
-- `fido.iot.pem.dev`
-
-  The location of the PEM file containing the device keys (private and public).
-  If not set, a hardcoded key is used - see the Java source for details.
-
-  There is no default. Provide value './device.pem' to use the existing default EC-256 key-pair.
-
-### Running the FIDO IoT HTTP Java Device Sample
-```
-$ cd <fido-iot-src>/device
-$ mvn -Dfido.iot.url.di=<di-server-URL> -Dfido.iot.pem.dev=<device-PEM-file> exec:java
-```
-
-Alternatively,
-```
-$ cd <fido-iot-src>/demo/device
-$ java -Dfido.iot.url.di=<di-server-URL> -Dfido.iot.pem.dev=<device-PEM-file> -jar device.jar
-```
-
-The `device-PEM-file` must contain the following PEM-encoded data:
-- The device's private key
-- The device's public key or certificate.
-
-The device will initialize and exit.  A `credential.bin` file will be created containing the device state.
-Removing this file will make the device re-initialize the next time it runs.
-
-The initialization (manufacturer) server must be available during this step.
-
-```
-$ mvn -Dfido.iot.pem.dev=<device-PEM-file> exec:java
-```
-
-The device will be onboarded.
-
-The rendezvous and owner servers must be available during this step.
-
-### Running a demo using Component Samples
-
-1. Start the FIDO IoT Manufacturer Sample as per the steps outlined in [Running the FIDO IoT Manufacturer Sample](#running-the-fido-iot-manufacturer-sample).
-
-2. Complete Device Initialization (DI) by starting the FIDO IoT HTTP Java Device Sample as per the steps outlined in [Running the FIDO IoT HTTP Java Device Sample](#running-the-fido-iot-http-java-device-sample). Delete any existing 'credential.bin' before starting the device.
-
-3. Complete Ownership Voucher Extension by using the API `GET /api/v1/vouchers/<serial_no>` and save the Ownership Voucher. By default, existing customer with customer Id '1', is assigned to the device. To add a new customer and assign the inserted customer to the device, please refer to [FIDO IoT Manufacturer REST APIs](#fido-iot-manufacturer-rest-apis) for more information about the API.
-
-4. Start the FIDO IoT RV Sample as per the steps outlined in [Running the FIDO IoT RV Sample](#running-the-fido-iot-rv-sample).
-
-5. Start the FIDO IoT Owner Sample as per the steps outlined in [Running the FIDO IoT Owner Sample](#running-the-fido-iot-owner-sample). Import the extended Ownership voucher from Step#3 into the Owner database by using the API `POST /api/v1/owner/vouchers/`. Please refer to [FIDO IoT Owner REST APIs](#fido-iot-owner-rest-apis) for more information about the API. Optionally, if service info transfer is needed, please refer to [Enabling Service info transfer](#enabling-service-info-transfer).
-
-6. Complete Transfer Ownership 1 and 2 (TO1 and TO2) by starting the FIDO IoT HTTP Java Device Sample again. The previously created 'credential.bin' from Step#2 will be used directly by the Device.
-
-### Service info setup between FIDO IoT HTTP Java Device Sample and FIDO IoT Owner Sample
-
-The FIDO IoT HTTP Java Device Sample curretly supports `sdo_sys` module for interpreting received owner service info and `devmod` module to share device service info with Owner.
-
-- `sdo_sys` Owner service info module: This module supports the following 3 message names as listed below to interpret the service info as received from the Owner. The basic functionality of this module is to support payload/script transfers and basic command execution.  A sample format looks like 'sdo_sys:filedesc=filename, sdo_sys:write=filecontent,sdo_sys:exec=command-to-execute'.
-
-    *filedesc* - The name to be given to the file once it is transferred. Upon receiving this, device creates a file with the given name and opens stream to write into it.
-
-    *write* - The payload/content (script, binaries, and others) that is sent to the device. Upon receiving this, device writes the content into the open stream as given by the preceeding 'filedesc' message.
-
-    *exec* - The command that will be executed at the device. Device executes the command as received.
-
-***NOTE*** The comma-separated values must be ordered such that the 'filedesc' and 'write' objects are one after the other pair-wise, followed by the 'exec' commands.
-
-- `devmod` Device service info module: This module supports multiple messages as listed down in the protocol specification, that are sent to the Owner as Device Service info. A sample format looks like 'devmod:active=1'.
-
-The FIDO IoT Owner Sample currently supports the same `sdo_sys` module to send Owner service info to the Device and `devmod` module to store the received Device Service info. Few sample service info values, as present in \<fido-iot-src\>/demo/owner/serviceinfo/sample-values/ are populated into the database table 'OWNER_SERVICEINFO' as byte arrays. For keeping the association between the Device and the service info values to transfer, 'GUID_OWNERSVI' database table is used. When a Device is inserted into the database table 'TO2_DEVICES', it'll not have any association with the service info values, and so by default, no service info is transferred to the Device.
-
-#### Enabling Service info transfer
-
-To enable service info transfer to a Device with a given GUID, following are the steps:
-
-1. (Optional) Insert required Service info values into the database table 'OWNER_SERVICEINFO' using the API `POST /api/v1/owner/svivalues/?id=<ServiceInfoId>&isCborEncoded=<boolean>`. More information about the same is provided in section [FIDO IoT Owner REST APIs](#fido-iot-owner-rest-apis). If the required service info already exists in the table, go on to the next step.
-
-2. (Mandatory) Insert required association between the Device and Service info values to transfer using the API `POST /api/v1/owner/svi/?guid=<guid>`. More information about the same is provided in section [FIDO IoT Owner REST APIs](#fido-iot-owner-rest-apis). As a referance, please see \<fido-iot-src\>/demo/owner/serviceinfo/sample-svi.csv, which says that Owner will transfer the column 'Content' of serviceinfoIds 'payload.bin' and 'package.sh', which the device will store in files named by the column 'Content' of serviceinfoids 'payload_name' and 'package_name'. Additionally, the Owner transfers the command as specified in column 'Content' of serviceinfoId 'binsh-linux', to be executed by the Device.
+Refer to [Demo README](demo/README.md) for steps to run component sample demo.

--- a/demo/README.md
+++ b/demo/README.md
@@ -134,8 +134,8 @@ The FIDO IoT Owner Sample currently supports the same `sdo_sys` module to send O
 
 # Enabling Service info transfer
 
-To enable service info transfer to a Device with a given GUID, following are the steps:
+To enable service info transfer to a Device with a given GUID by following are the steps below:
 
 1. (Optional) Insert required Service info values into the database table 'OWNER_SERVICEINFO' using the API `POST /api/v1/owner/svivalues/?id=<serviceinfo_id>&isCborEncoded=<boolean_value>`. More information about the same is provided in section [FIDO IoT Owner REST APIs](owner/README.md/#fido-iot-owner-rest-apis). If the required service info already exists in the table, go on to the next step.
 
-2. (Mandatory) Insert required association between the Device and Service info values to transfer using the API `POST /api/v1/owner/svi/?guid=<guid>`. More information about the same is provided in section [FIDO IoT Owner REST APIs](owner/README.md/#fido-iot-owner-rest-apis). As a referance, please see \<fido-iot-src\>/demo/owner/serviceinfo/sample-svi.csv, which says that Owner will transfer the column 'Content' of serviceinfoIds 'payload.bin' and 'package.sh', which the device will store in files named by the column 'Content' of serviceinfoids 'payload_name' and 'package_name'. Additionally, the Owner transfers the command as specified in column 'Content' of serviceinfoId 'binsh-linux', to be executed by the Device.
+2. (Mandatory) Insert required association between the Device and Service info values to transfer using the API `POST /api/v1/owner/svi/?guid=<guid>`. More information about the same is provided in section [FIDO IoT Owner REST APIs](owner/README.md/#fido-iot-owner-rest-apis). As a referance, please see \<fido-iot-src\>/demo/owner/serviceinfo/sample-svi.csv, which says that Owner will transfer the column 'Content' of serviceinfoIds, 'payload.bin', and 'package.sh', which the device will store in files named by the column 'Content' of serviceinfoids 'payload_name' and 'package_name'. Additionally, the Owner transfers the command as specified in column 'Content' of serviceinfoId 'binsh-linux', to be executed by the Device.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,12 +1,10 @@
 # Table of Contents
 1. [System Requirements](#system-requirements)
 2. [Docker Commands](#docker-commands)
-3. [Start Manufacturer Service](#start-manufacturer-service)
-4. [Start Reseller Service](#start-reseller-service)
-5. [Start Rendezvous Service](#start-rendezvous-service)
-6. [Start Owner Service](#start-owner-service)
-7. [Start Device Service](#start-device-service)
-8. [Inserting Keys into Keystore](#inserting-keys-into-keystore)
+3. [Inserting Keys into Keystore](#inserting-keys-into-keystore)
+4. [Running Demo](#running-demo)
+5. [Service Info Setup](#service-info-setup-between-fido-iot-http-java-device-sample-and-fido-iot-owner-sample)
+6. [Enabling Service info transfer](#enabling-service-info-transfer)
 
 # System Requirements
 
@@ -59,25 +57,30 @@ $ sudo docker rmi <image-id>
 $ sudo docker system prune -a
 ```
 
-# Start Manufacturer Service
+# Configuring Proxies
+Update the proxy information in `_JAVA_OPTIONS` as
 
-Refer [Demo Manufacturer README](manufacturer/README.md) to start the service.
+```
+_JAVA_OPTIONS=-Dhttp.proxyHost=http_proxy_host -Dhttp.proxyPort=http_proxy_port -Dhttps.proxyHost=https_proxy_host -Dhttps.proxyPort=https_proxy_port
+```
 
-# Start Reseller Service
+where
 
-Refer [Demo Reseller README](reseller/README.md) to start the service.
+`http_proxy_host`: Represents the HTTP proxy hostname. Typically, it is an IP address or domain name in the proxy URL.
 
-# Start Rendezvous Service
+`http_proxy_port`: Represents the HTTP proxy port. Typically, it is the port number in the proxy URL.
 
-Refer [Demo Rendezvous README](rv/README.md) to start the service.
+`https_proxy_host`: Represents the HTTPS proxy hostname. Typically, it is an IP address or domain name in the proxy URL.
 
-# Start Owner Service
+`https_proxy_port`: Represents the HTTPS proxy port. Typically, it is the port number in the proxy URL.
 
-Refer [Demo Owner README](owner/README.md) to start the service.
+Specify the combination of the hostname and the port information together for either HTTP, HTTPS, or both. For example, if the HTTP proxy is 'http://myproxy.com:900', then the following updates will be made to the properties:
 
-# Start Device Service
+http_proxy_host: myproxy.com
 
-Refer [Demo Device README](device/README.md) to start the service.
+http_proxy_port: 900
+
+If no proxy needs to be specified, do not add these properties to your _JAVA_OPTIONS.
 
 # Inserting Keys into Keystore
 
@@ -96,3 +99,43 @@ Assuming that there is already an existing certificate named 'certificate.pem' a
 `$ keytool -importkeystore -destkeystore path/to/dest-keystore.p12 -srckeystore src-keystore.p12 -srcstoretype PKCS12 -alias newkeypair`
 
 ***NOTE*** The password entered in Step 1 to generate the src-keystore.p12 must be the same as that of dest-keystore.p12, that is, the password of the newly created keystore must match the existing keystore where it will be imported to.
+
+# Running Demo
+
+1. Start the FIDO IoT Manufacturer Sample as per the steps outlined in [Manufacturer README](manufacturer/README.md).
+
+2. Complete Device Initialization (DI) by starting the FIDO IoT HTTP Java Device Sample as per the steps outlined in [Device README](device/README.md). Delete any existing 'credential.bin' before starting the device.
+
+3. Complete Ownership Voucher Extension by using the API `GET /api/v1/vouchers/<serial_no>` and save the Ownership Voucher. By default, existing customer with customer Id '1', is assigned to the device. To add a new customer and assign the inserted customer to the device, please refer to [FIDO IoT Manufacturer REST APIs](manufacturer/README.md/#fido-iot-manufacturer-rest-apis) for more information about the API.
+
+4. Start the FIDO IoT RV Sample as per the steps outlined in [RV README](rv/README.md).
+
+5. Start the FIDO IoT Owner Sample as per the steps outlined in [Owner README](owner/README.md). Import the extended Ownership voucher from Step#3 into the Owner database by using the API `POST /api/v1/owner/vouchers/`. Please refer to [FIDO IoT Owner REST APIs](owner/README.md/#fido-iot-owner-rest-apis) for more information about the API. Optionally, if service info transfer is needed, please refer to [Enabling Service info transfer](#enabling-service-info-transfer).
+
+6. Complete Transfer Ownership 1 and 2 (TO1 and TO2) by starting the FIDO IoT HTTP Java Device Sample again. The previously created 'credential.bin' from Step#2 will be used directly by the Device.
+
+# Service info setup between FIDO IoT HTTP Java Device Sample and FIDO IoT Owner Sample
+
+The FIDO IoT HTTP Java Device Sample curretly supports `sdo_sys` module for interpreting received owner service info and `devmod` module to share device service info with Owner.
+
+- `sdo_sys` Owner service info module: This module supports the following 3 message names as listed below to interpret the service info as received from the Owner. The basic functionality of this module is to support payload/script transfers and basic command execution.  A sample format looks like 'sdo_sys:filedesc=filename, sdo_sys:write=filecontent,sdo_sys:exec=command-to-execute'.
+
+    *filedesc* - The name to be given to the file once it is transferred. Upon receiving this, device creates a file with the given name and opens stream to write into it.
+
+    *write* - The payload/content (script, binaries, and others) that is sent to the device. Upon receiving this, device writes the content into the open stream as given by the preceeding 'filedesc' message.
+
+    *exec* - The command that will be executed at the device. Device executes the command as received.
+
+***NOTE*** The comma-separated values must be ordered such that the 'filedesc' and 'write' objects are one after the other pair-wise, followed by the 'exec' commands.
+
+- `devmod` Device service info module: This module supports multiple messages as listed down in the protocol specification, that are sent to the Owner as Device Service info. A sample format looks like 'devmod:active=1'.
+
+The FIDO IoT Owner Sample currently supports the same `sdo_sys` module to send Owner service info to the Device and `devmod` module to store the received Device Service info. Few sample service info values, as present in \<fido-iot-src\>/demo/owner/serviceinfo/sample-values/ are populated into the database table 'OWNER_SERVICEINFO' as byte arrays. For keeping the association between the Device and the service info values to transfer, 'GUID_OWNERSVI' database table is used. When a Device is inserted into the database table 'TO2_DEVICES', it'll not have any association with the service info values, and so by default, no service info is transferred to the Device.
+
+# Enabling Service info transfer
+
+To enable service info transfer to a Device with a given GUID, following are the steps:
+
+1. (Optional) Insert required Service info values into the database table 'OWNER_SERVICEINFO' using the API `POST /api/v1/owner/svivalues/?id=<serviceinfo_id>&isCborEncoded=<boolean_value>`. More information about the same is provided in section [FIDO IoT Owner REST APIs](owner/README.md/#fido-iot-owner-rest-apis). If the required service info already exists in the table, go on to the next step.
+
+2. (Mandatory) Insert required association between the Device and Service info values to transfer using the API `POST /api/v1/owner/svi/?guid=<guid>`. More information about the same is provided in section [FIDO IoT Owner REST APIs](owner/README.md/#fido-iot-owner-rest-apis). As a referance, please see \<fido-iot-src\>/demo/owner/serviceinfo/sample-svi.csv, which says that Owner will transfer the column 'Content' of serviceinfoIds 'payload.bin' and 'package.sh', which the device will store in files named by the column 'Content' of serviceinfoids 'payload_name' and 'package_name'. Additionally, the Owner transfers the command as specified in column 'Content' of serviceinfoId 'binsh-linux', to be executed by the Device.

--- a/demo/device/README.md
+++ b/demo/device/README.md
@@ -30,7 +30,7 @@ Some software settings are runtime-configurable via Java properties.  They inclu
   The location of the PEM file containing the device keys (private and public).
   If not set, a hardcoded key is used - see the Java source for details.
 
-  There is no default.
+  There is no default. Provide value `./device.pem` to use the existing default EC-256 key-pair.
 
 # Starting the Device service
 

--- a/demo/device/README.md
+++ b/demo/device/README.md
@@ -1,6 +1,6 @@
 # Getting the executable
 
-Use following commands to build FIDO IoT HTTP Device Component sample source.
+Use the following commands to build FIDO IoT HTTP Device Component sample source.
 ```
 $ cd <fido-iot-src>/service/component-samples/http-device-sample/
 $ mvn clean install

--- a/demo/manufacturer/README.md
+++ b/demo/manufacturer/README.md
@@ -8,12 +8,95 @@ $ mvn clean install
 
 This will copy the required executables and libraries into \<fido-iot-src\>/demo/manufacturer/.
 
+# Configuring the FIDO IoT Manufacturer Sample
+
+Some required runtime arguments
+
+- `manufacturer_di_port`
+
+  Manufacturer server port.
+
+  Default value: 8039.
+
+- `manufacturer_database_connection_url`
+
+   JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file
+
+  Default value: jdbc:h2:tcp://localhost:8049/./target/data/mfg
+
+- `manufacturer_database_username`
+
+  Manufacturer database username.
+
+  Default value: sa
+
+- `manufacturer_database_password`
+
+  Manufacturer database password.
+
+  Default value: <no_password>
+
+- `manufacturer_database_port`
+
+  Manufacturer database port number.
+
+  Default value: 8049
+
+- `catalina_home`
+
+  Tomcat configuration.
+
+  Docker default: ./target/tomcat
+
+- `manufacturer_keystore_password`
+
+  Keystore password for manufacturer_keystore.p12 and the internal softHSM's PKCS11 keystore.
+
+  Default value: MfgKs@3er
+
+- `manufacturer_api_user`
+
+  Username for the non-SDO REST API calls.
+
+  Default value: apiUser
+
+- `manufacturer_api_password`
+
+  Password for the non-SDO REST API calls.
+
+  Default value: MfgApiPass123
+
+# Enabling Remote Access to DB
+
+Remote access to H2 Sample Storage DB has been disabled by default. Enabling the access creates a security hole in the system which makes it vulnerable to Remote Code Execution.
+
+To enable remote access to DB update the `db.tcpServer` and `webAllowOthers` properties in `<fido-iot-src>/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerApp.java` file
+
+```
+db.tcpServer = -tcp -tcpAllowOthers -ifNotExists -tcpPort <manufacturer_db_port>
+webAllowOthers = true
+```
+
+**IMPORTANT: NOT recommended to enable this setting especially on production systems.**
+
 # Starting the Manufacturer service
 
 Refer the [Docker Commands](../README.md/#docker-commands) to start the service.
 
 ***NOTE*** The database file located at \<fido-iot-src\>/demo/manufacturer/target/data/mfg.mv.db is not deleted during 'mvn clean'. As as result the database schema and tables are persisted across docker invocations. Please delete the file manually, in case you encounter any error due to the persisted stale data.
 
+# FIDO IoT Manufacturer REST APIs
+
+| Operation                      | Description                        | Path/Query Parameters    | Content Type   |Request Body  | Response Body |
+| ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|
+| POST /api/v1/assign/?id=<customer_id>&guid=<device_guid> | Assigns customer ID to voucher having the input GUID. | Query - id: Customer ID, guid = Device GUID | | | |
+| GET /api/v1/vouchers/<serial_no> | Gets extended voucher with the serial number. | Path - Device Serial Number | | | Ownership Voucher |
+| POST /api/v1/customers/?id=<customer_id>&name=<customer_name> | Adds customer with the given ID and Public key in PEM format. | Query - id: Customer Id, name: Customer Name | text/plain; charset=us-ascii | Customer PEM formatted Public keys | |
+| POST /api/v1/rvinfo/ | Updates RV Info in `MT_SETTINGS` table | | text/plain; charset=us-ascii | RV Info | | |
+
+
 # Inserting keys into Manufacturer keystore
 
 The PKCS12 keystore file \<fido-iot-src\>/demo/manufacturer/manufacturer_keystore.p12 contains the default manufacturer keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to the section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/manufacturer/manufacturer_keystore.p12.
+
+**IMPORTANT** This is an example implementation using simplified credentials. This must be changed while performing production deployment

--- a/demo/manufacturer/README.md
+++ b/demo/manufacturer/README.md
@@ -1,6 +1,6 @@
 # Getting the executable
 
-Use following commands to build FIDO IoT Manufacturer Component sample source.
+Use the following commands to build FIDO IoT Manufacturer Component sample source.
 ```
 $ cd <fido-iot-src>/service/component-samples/manufacturer/
 $ mvn clean install
@@ -83,7 +83,7 @@ webAllowOthers = true
 
 Refer the [Docker Commands](../README.md/#docker-commands) to start the service.
 
-***NOTE*** The database file located at \<fido-iot-src\>/demo/manufacturer/target/data/mfg.mv.db is not deleted during 'mvn clean'. As as result the database schema and tables are persisted across docker invocations. Please delete the file manually, in case you encounter any error due to the persisted stale data.
+***NOTE*** The database file located at \<fido-iot-src\>/demo/manufacturer/target/data/mfg.mv.db is not deleted during 'mvn clean'. As a result, the database schema and tables are persisted across docker invocations. Please delete the file manually, if you encounter any error due to persisted stale data.
 
 # FIDO IoT Manufacturer REST APIs
 
@@ -97,6 +97,6 @@ Refer the [Docker Commands](../README.md/#docker-commands) to start the service.
 
 # Inserting keys into Manufacturer keystore
 
-The PKCS12 keystore file \<fido-iot-src\>/demo/manufacturer/manufacturer_keystore.p12 contains the default manufacturer keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to the section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/manufacturer/manufacturer_keystore.p12.
+The PKCS12 keystore file \<fido-iot-src\>/demo/manufacturer/manufacturer_keystore.p12 contains the default manufacturer keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/manufacturer/manufacturer_keystore.p12.
 
 **IMPORTANT** This is an example implementation using simplified credentials. This must be changed while performing production deployment

--- a/demo/owner/README.md
+++ b/demo/owner/README.md
@@ -1,6 +1,6 @@
 # Getting the executable
 
-Use following commands to build FIDO IoT Owner Component sample source.
+Use the following commands to build FIDO IoT Owner Component sample source.
 ```
 $ cd <fido-iot-src>/service/component-samples/owner/
 $ mvn clean install
@@ -20,7 +20,7 @@ Some required runtime arguments
 
 - `owner_database_connection_url`
 
-  JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file.
+  JDBC URL for connection to database. Includes the database driver name, port number for database, and the location of `.db` file.
 
   Default value: jdbc:h2:tcp://localhost:8051/./target/data/ops
 
@@ -120,7 +120,7 @@ webAllowOthers = true
 
 Refer to the section [Docker Commands](../README.md/#docker-commands) to start the service.
 
-***NOTE*** The database file located at \<fido-iot-src\>/demo/owner/target/data/ops.mv.db is not deleted during 'mvn clean'. As as result the database schema and tables are persisted across docker invocations. Please delete the file manually, in case you encounter any error due to the persisted stale data.
+***NOTE*** The database file located at \<fido-iot-src\>/demo/owner/target/data/ops.mv.db is not deleted during 'mvn clean'. As a result, the database schema and tables are persisted across docker invocations. Please delete the file manually, if you encounter any error due to persisted stale data.
 
 # FIDO IoT Owner REST APIs
 
@@ -139,6 +139,6 @@ Refer to the section [Docker Commands](../README.md/#docker-commands) to start t
 
 # Inserting keys into Owner keystore
 
-The PKCS12 keystore file \<fido-iot-src\>/demo/owner/owner_keystore.p12 contains the default Owner keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to the section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/owner/owner_keystore.p12.
+The PKCS12 keystore file \<fido-iot-src\>/demo/owner/owner_keystore.p12 contains the default Owner keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/owner/owner_keystore.p12.
 
 **IMPORTANT** This is an example implementation using simplified credentials. This must be changed while performing production deployment

--- a/demo/owner/README.md
+++ b/demo/owner/README.md
@@ -8,12 +8,137 @@ $ mvn clean install
 
 This will copy the required executables and libraries into \<fido-iot-src\>/demo/owner/.
 
+# Configuring the FIDO IoT Owner Sample
+
+Some required runtime arguments
+
+- `owner_to2_port`
+
+  Owner server port.
+
+  Default value: 8042
+
+- `owner_database_connection_url`
+
+  JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file.
+
+  Default value: jdbc:h2:tcp://localhost:8051/./target/data/ops
+
+- `owner_database_username`
+
+  Owner database username.
+
+  Default value: sa
+
+- `owner_database_password`
+
+  Owner database password.
+
+  Default value: <no-password>
+
+- `owner_database_port`
+
+  RV database port number.
+
+  Default value: 8050
+
+- `epid_online_url`
+
+  EPID Verification Service URL for EPID device signature verification.
+
+  Default value: https://verify.epid-sbx.trustedservices.intel.com/
+  Other server options: https://verify.epid.trustedservices.intel.com/ (production EPID verification server), https://localhost:1180 (onprem verification service)
+
+- `catalina_home`
+
+  Tomcat configuration for cataline home.
+
+  Default value: ./target/tomcat
+
+- `owner_keystore_password`
+
+  Keystore password for owner_keystore.p12 and the internal softHSM's PKCS11 keystore.
+
+  Default value: OnrKstr1
+
+- `owner_to0_scheduling_enabled`
+
+  Auto completes TO0 for GUIDs with DI complete state.
+
+  Default value: false
+
+- `owner_to0_scheduling_interval`
+
+  Time interval to check database for GUIDs with pending TO0.
+
+  Default value: 300s
+
+- `owner_to0_rv_blob`
+
+  Information containing network address of prospective owner. Owner shares this information with RV during TO0. RV, then shares the same during TO1. Device, then uses this information to initiate TO2 protocol.
+
+  Default value: http://localhost:8042?ipaddress=127.0.0.1
+
+- `owner_api_user`
+
+  Username for the non-SDO REST API calls.
+
+  Default value: apiUser
+
+- `owner_api_password`
+
+  Password for the non-SDO REST API calls.
+
+  Default value: OwnerApiPass123
+
+- `owner_svi_values`
+
+  Path to the directory that contains default sample owner serviceinfo values. The filenames are used as identifiers in the database, while the actual file content is the requisite serviceinfo that is transferred to the device. Only used for demo purposes and should not be modified.
+
+  Default value: ./serviceinfo/sample-values
+
+- `owner_svi_string`
+
+  Path to the file that contains default sample svi string that maps serviceinfo values to module names and messages. Only used for demo purposes and should not be modified.
+
+  Docker default: ./serviceinfo/sample-svi.csv
+
+# Enabling Remote Access to DB
+
+Remote access to H2 Sample Storage DB has been disabled by default. Enabling the access creates a security hole in the system which makes it vulnerable to Remote Code Execution.
+
+To enable remote access to DB update the `db.tcpServer` and `webAllowOthers` properties in `<fido-iot-src>/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java` file
+
+```
+db.tcpServer = -tcp -tcpAllowOthers -ifNotExists -tcpPort <owner_db_port>
+webAllowOthers = true
+```
+
+**IMPORTANT: NOT recommended to enable this setting especially on production systems.**
+
 # Starting the owner service
 
 Refer to the section [Docker Commands](../README.md/#docker-commands) to start the service.
 
 ***NOTE*** The database file located at \<fido-iot-src\>/demo/owner/target/data/ops.mv.db is not deleted during 'mvn clean'. As as result the database schema and tables are persisted across docker invocations. Please delete the file manually, in case you encounter any error due to the persisted stale data.
 
+# FIDO IoT Owner REST APIs
+
+| Operation                      | Description                        | Path/Query Parameters    | Content Type   |Request Body  | Response Body |
+| ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|
+| GET /api/v1/owner/vouchers/    | Returns all voucher available in `TO2_DEVICES` table. | | | | Comma-separated list of GUIDs |
+| GET /api/v1/owner/vouchers/?id=<device_guid> | Returns the voucher for the specified GUID. | Query - id: Device GUID | | | Ownership voucher |
+| POST /api/v1/owner/vouchers/ | Insert voucher against the specified GUID in `TO2_DEVICES` table. | | application/cbor | Content of Ownership voucher in binary format | |
+| DELETE /api/v1/owner/vouchers/?id=<device_guid> | Deletes voucher of the specified GUID from the `TO2_DEVICES` table. | Query - id: Device GUID | | | |
+| POST /api/v1/owner/svivalues/?id=\<serviceinfo_id>&isCborEncoded=<boolean_value> | Adds serviceinfo entry to `OWNER_SERVICEINFO` table. The query parameter 'isCborEncoded' should be 'true' for CBOR encoded binary data that will never be split into smaller chunks while transferring to the device (small in length, to be used for CBOR primitives such as boolean, int, array and map), and it should be 'false' (preferably) for other binary data that could be splitted into smaller chunks and transferred across messages (for example binary values, string). | Query - id: Service info ID, isCborEncoded: Boolean | application/octet-stream or application/cbor | Content of Serviceinfo in binary format. | |
+| DELETE /api/v1/owner/svivalues/?id=<serviceinfo_id> | Deletes the serviceinfo values from `OWNER_SERVICEINFO` table. | Query - id: Service info ID | | | |
+| POST /api/v1/owner/svi/?guid=<device_guid> | Adds owner serviceinfo for the GUID in `GUID_OWNERSVI` table, that will be transferred to the device in the insertion order. The format is `Entry1,Entry2,Entry3` and so on, where each Entry contains `moduleName:messageName=serviceInfoId`. Here, the 'content' corresponding to the 'serviceInfoId' is transferred to the device. Please see \<fido-iot-src\>/demo/owner/serviceinfo/sample-svi.csv as an example for the above format, where moduleName is 'sdo_sys' and messageName is either one of 'filedesc', 'write' and 'exec'. The order of each 'Entry' is important as this order decides the sequence in which the Owner will transfer the Service info. | Query - guid: Device GUID | application/text | SVI string | |
+| DELETE /api/v1/owner/svi/?guid=<device_guid> | Deletes owner serviceinfo for the GUID from the `GUID_OWNERSVI` table. | Query - guid: Device GUID | | | |
+
+***NOTE*** These REST APIs use Digest authentication. `owner_api_user` and `owner_api_password` properties specify the credentials to be used while making the REST calls.
+
 # Inserting keys into Owner keystore
 
 The PKCS12 keystore file \<fido-iot-src\>/demo/owner/owner_keystore.p12 contains the default Owner keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to the section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/owner/owner_keystore.p12.
+
+**IMPORTANT** This is an example implementation using simplified credentials. This must be changed while performing production deployment

--- a/demo/reseller/README.md
+++ b/demo/reseller/README.md
@@ -8,12 +8,115 @@ $ mvn clean install
 
 This will copy the required executables and libraries into \<fido-iot-src\>/demo/reseller/.
 
+# Configuring the FIDO IoT Reseller Sample
+
+Some required runtime arguments
+
+- `reseller_api_port`
+
+  Reseller server port.
+
+  Default value: 8070
+
+- `reseller_database_connection_url`
+
+   JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file
+
+  Default value: jdbc:h2:tcp://localhost:8071/<path-to-user-dir>
+
+- `reseller_database_username`
+
+  Reseller database username.
+
+  Default value: sa
+
+- `reseller_database_password`
+
+  Reseller database password.
+
+  Default value: <no-password>
+
+- `reseller_database_port`
+
+  Reseller database port number.
+
+  Default value: 8071
+
+- `reseller_database_driver`
+
+  Reseller database driver.
+
+  Default value: org.h2.Driver
+
+- `reseller_api_user`
+
+  Reseller API username.
+
+  Default value: admin
+
+- `reseller_api_password`
+
+  Reseller API password.
+
+  Default value: test
+
+- `reseller_home`
+
+  Tomcat configuration for catalina home.
+
+  Default value: catalina.home
+
+- `reseller_keystore_type`
+
+  Reseller keystore type
+
+  Default value: PKCS11
+
+- `reseller_keystore_password`
+
+  Reseller keystore password
+
+  Default value: 123456
+
+- `user.dir`
+
+  Base path for jdbc `.db` file location.
+
+# Enabling Remote Access to DB
+
+Remote access to H2 Sample Storage DB has been disabled by default. Enabling the access creates a security hole in the system which makes it vulnerable to Remote Code Execution.
+
+To enable remote access to DB update the `db.tcpServer` and `webAllowOthers` properties in `<fido-iot-src>/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerServerApp.java` file
+
+```
+db.tcpServer = -tcp -tcpAllowOthers -ifNotExists -tcpPort <reseller_db_port>
+webAllowOthers = true
+```
+
+**IMPORTANT: NOT recommended to enable this setting especially on production systems.**
+
 # Starting the Reseller service
 
 Refer the [Docker Commands](../README.md/#docker-commands) to start the service.
 
 ***NOTE*** The database file located at \<fido-iot-src\>/demo/reseller/target/data/reseller.mv.db is not deleted during 'mvn clean'. As as result the database schema and tables are persisted across docker invocations. Please delete the file manually, in case you encounter any error due to the persisted stale data.
 
+# FIDO IoT Reseller REST APIs
+
+| Operation                      | Description                        | Path/Query Parameters    | Content Type   |Request Body  | Response Body |
+| ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|
+| GET /api/v1/resell/vouchers/<serial_number>?id=<customer_id> | Assigns the customer and returns the extended voucher for the given serial number from `RT_DEVICES` table. | Query - id: Customer Id, Path - Device Serial Number | | | Ownership voucher |
+| POST /api/v1/resell/vouchers/<serial_number> | Adds voucher to `RT_DEVICES` table against the serial number. | Path - Device Serial Number | application/cbor | Ownership voucher | |
+| DELETE /api/v1/resell/vouchers/<serial_number> | Deletes voucher from `RT_DEVICES` table with the specified serial number. | Path - Device Serial Number | | | |
+| POST /api/v1/resell/customers/?id=<customer_id>&name=<customer_name> | Adds customer keyset to `RT_CUSTOMERS` table. | Query - id: Customer Id, name: Customer Name | text/plain; charset=us-ascii | Customer PEM formatted Public keys | |
+| DELETE /api/v1/resell/customers/<customer_id> | Deletes customer keyset from `RT_CUSTOMERS` table. | Path - Customer Id | | | |
+| POST /api/v1/resell/keys/?alias=<keystore_alias> | Adds new Reseller keys to the keystore with the given alias | Query - alias: Alias to be added in keystore | | PEM formatted certificate and private key | |
+| DELETE /api/v1/resell/keys/?alias=<keystore_alias> | Deletes the keys corresponding to the input alias from keystore. | Query - alias: Alias to be removed from keystore | | | |
+
+***NOTE*** These REST APIs use Digest authentication. `reseller_api_user` and `reseller_api_password` properties specify the credentials to be used while making the REST calls.
+
 # Inserting keys into Reseller keystore
 
 The PKCS12 keystore file \<fido-iot-src\>/demo/reseller/reseller_keystore.p12 contains the default reseller keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to the section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/reseller/reseller_keystore.p12.
+
+**IMPORTANT** This is an example implementation using simplified credentials. This must be changed while performing production deployment

--- a/demo/reseller/README.md
+++ b/demo/reseller/README.md
@@ -1,6 +1,6 @@
 # Getting the executable
 
-Use following commands to build FIDO IoT Reseller Component sample source.
+Use the following commands to build FIDO IoT Reseller Component sample source.
 ```
 $ cd <fido-iot-src>/service/component-samples/reseller/
 $ mvn clean install
@@ -20,7 +20,7 @@ Some required runtime arguments
 
 - `reseller_database_connection_url`
 
-   JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file
+   JDBC URL for connection to database. Includes the database driver name, port number for database, and the location of `.db` file
 
   Default value: jdbc:h2:tcp://localhost:8071/<path-to-user-dir>
 
@@ -99,7 +99,7 @@ webAllowOthers = true
 
 Refer the [Docker Commands](../README.md/#docker-commands) to start the service.
 
-***NOTE*** The database file located at \<fido-iot-src\>/demo/reseller/target/data/reseller.mv.db is not deleted during 'mvn clean'. As as result the database schema and tables are persisted across docker invocations. Please delete the file manually, in case you encounter any error due to the persisted stale data.
+***NOTE*** The database file located at \<fido-iot-src\>/demo/reseller/target/data/reseller.mv.db is not deleted during 'mvn clean'. As a result, the database schema and tables are persisted across docker invocations. Please delete the file manually, if you encounter any error due to persisted stale data.
 
 # FIDO IoT Reseller REST APIs
 
@@ -117,6 +117,6 @@ Refer the [Docker Commands](../README.md/#docker-commands) to start the service.
 
 # Inserting keys into Reseller keystore
 
-The PKCS12 keystore file \<fido-iot-src\>/demo/reseller/reseller_keystore.p12 contains the default reseller keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to the section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/reseller/reseller_keystore.p12.
+The PKCS12 keystore file \<fido-iot-src\>/demo/reseller/reseller_keystore.p12 contains the default reseller keys that are imported into the softHSM keystore inside the container, during startup. It contains 3 PrivateKeyEntry with algorithm types: EC-256, EC-384 and RSA-2048, and should continue to hold PrivateKeyEntry with different algorithms. To insert/replace an existing PrivateKeyEntry of any particular algorithm, refer to section [Inserting Keys into Keystore](../README.md/#inserting-keys-into-keystore) to insert new certificate/private-key pair into \<fido-iot-src\>/demo/reseller/reseller_keystore.p12.
 
 **IMPORTANT** This is an example implementation using simplified credentials. This must be changed while performing production deployment

--- a/demo/rv/README.md
+++ b/demo/rv/README.md
@@ -8,6 +8,100 @@ $ mvn clean install
 
 This will copy the required executables and libraries into <fido-iot-src>/demo/rv/.
 
+# Configuring the FIDO IoT RV Sample
+
+Some required runtime arguments
+
+- `rv_port`
+
+  RV server port.
+
+  Default value: 8040
+
+- `rv_database_connection_url`
+
+   JDBC URL for connection to database. Includes the database driver name, port number for database and the location of `.db` file
+
+  Default value: jdbc:h2:tcp://localhost:8050/./target/data/rvs
+
+- `rv_database_username`
+
+  RV database username.
+
+  Default value: sa
+
+- `rv_database_password`
+
+  RV database password.
+
+  Default value: <no-password>
+
+- `rv_database_port`
+
+  RV database port number.
+
+  Default value: 8050
+
+- `epid_online_url`
+
+  EPID Verification Service URL for EPID device signature verification.
+
+  Default value: https://verify.epid-sbx.trustedservices.intel.com/
+  Other server options: https://verify.epid.trustedservices.intel.com/ (production EPID verification server), https://localhost:1180 (onprem verification service)
+
+- `catalina_home`
+
+  Tomcat configuration for catalina home.
+
+  Default value: ./target/tomcat
+
+# Enabling Remote Access to DB
+
+Remote access to H2 Sample Storage DB has been disabled by default. Enabling the access creates a security hole in the system which makes it vulnerable to Remote Code Execution.
+
+To enable remote access to DB update the `db.tcpServer` and `webAllowOthers` properties in `<fido-iot-src>/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java` file
+
+```
+db.tcpServer = -tcp -tcpAllowOthers -ifNotExists -tcpPort <rv_db_port>
+webAllowOthers = true
+```
+
+**IMPORTANT: NOT recommended to enable this setting especially on production systems.**
+
 # Starting the rv service
 
 Refer the [Docker Commands](../README.md/#docker-commands) to start the service.
+
+# Allowlist and Denylist Configuration
+
+- RV provides the option to allow and deny requests based on the owner, manufacturer and reseller public keys and based on the GUID used in the device ownership voucher
+header. 
+- To add entries to these allowlist and denylist, update the `config.properties` file in `<fido-iot-src>/storage/storage-rv-sample/src/main/resources` location.
+- Once updated, rebuild the code, rebuild RV docker image and then start the docker.
+- The hashes for the default public keys present of owner, manufacturer and reseller are already added in allowlist configuration of component sample. The table below lists them.
+
+  | Hashes in Allowlist | PRI-FIDOIOT Component |
+  | --- | --- |
+  | 42110E8F0F3184A1A5C51868BCBFF7144D66E41D1A188103C0264D5DA8BBCF88 | Manufacturer ECDSA 256 |
+  | 25D42F0536CE584E5812AB8750E80E7464742B4B65347BEA90AD4BBC71D3FFA6 | Manufacturer ECDSA 384 |
+  | 283ADF4CCB527C19A72CFB21A9FF7B555788E6B365CEF3A26C6B876EE0FFE017 | Manufacturer RSA 2048 |
+  | 85A481BBC2DA15EDD7301FF92BA2BB60093D5864A8207F9D78A399B32AB4CFF4 | Reseller ECDSA 256 |
+  | 31726603CB0751BFB926B6436369265557855744338FFC3307693E0D14D5241D | Reseller ECDSA 384 |
+  | 2ED65928AD50CB8542E648B9CD5C8B4BFB76DA870C723B16464F49F5140F7098 | Reseller RSA 2048 |
+  | 1DAC184C6A8BB2D00665F4CFC55B1F55AC9BFB4C899B06827C0C1990A1A0F74C | Owner ECDSA 256 |
+  | 834F83875910C8507CE935BE2F947DCF854E6554C3ACB79893ACF91220EA5D8B | Owner ECDSA 384 |
+  | 91984D7EE0BC1F153900401E6E0D0DC4F6F8472709AA1DAA9256429046C2E367 | Owner RSA 2048 |
+
+- To add entries to allowlist and denylist for public key, public key hash need to be calculated. Refer [Generating Public Key Hash](#calculate-sha256-hash-of-a-public-key) for the steps to generate public key hash from public key.
+
+**IMPORTANT** This is an example implementation using simplified credentials. This must be changed while performing production deployment
+
+# Calculate SHA256 hash of a public key
+
+```
+$ openssl x509 -in cert.pem -pubkey -noout | openssl enc -base64 -d > example_allowlist_publickey.der
+
+$ cat example_allowlist_publickey.der | openssl dgst -sha256 | awk '/s/{print toupper($2)}'
+```
+
+***NOTE:*** Input file cert.pem is an X509 certificate.

--- a/demo/rv/README.md
+++ b/demo/rv/README.md
@@ -1,6 +1,6 @@
 # Getting the executable
 
-Use following commands to build FIDO IoT RV Component sample source.
+Use the following commands to build FIDO IoT RV Component sample source.
 ```
 $ cd <fido-iot-src>/service/component-samples/rv/
 $ mvn clean install


### PR DESCRIPTION
All Component Sample related demo instructions are moved in the READMEs inside Demo folder. Top level README contains steps to perform demo using protocol samples and a link to Demo README for Component samples demo.

Added instructions to perform allowlist and denylist operations on RV component sample.

Added new APIs to the respective component REST contract.

Added instructions to enable remote access to DB.

Includes fix for github issues 74-79 and semantic fixes after proofread.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>