### PR TITLE
Fixing the Klocwork issues

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/epid/EpidMaterialService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/epid/EpidMaterialService.java
@@ -79,13 +79,12 @@ public class EpidMaterialService {
     switch (sgType) {
       case Const.SG_EPIDv10:
       case Const.SG_EPIDv11:
-        Composite certRequestSigInfo =
-            Composite.newArray().set(Const.FIRST_KEY, sgType).set(Const.SECOND_KEY, sigA.toBytes());
 
         byte[] certBytes = Const.EMPTY_BYTE;
         try {
           certBytes = getGroupCertSigma10(sigA);
         } catch (RuntimeException ex) {
+          System.out.println("Runtime Exception in getSigInfo");
           // intentional fall through
           // some EPID 1.1 groups have a cert 0 and others don't
         }
@@ -98,6 +97,7 @@ public class EpidMaterialService {
         try {
           certBytes = getGroupCertSigma11(sigA);
         } catch (RuntimeException ex) {
+          System.out.println("Runtime Exception in getSigInfo");
           // intentional fall through
         }
         sigInfoBytes.write(getLengthBytes(certBytes.length));
@@ -110,6 +110,7 @@ public class EpidMaterialService {
           sigRlBytes = getSigrl(sigA,
                   Const.EPID_PROTOCOL_VERSION_V2 + Const.URL_PATH_SEPARATOR +  Const.EPID_11);
         } catch (RuntimeException ex) {
+          System.out.println("Runtime Exception in getSigInfo");
           // intentional fall through
         }
         sigInfoBytes.write(getLengthBytes(sigRlBytes.length));

--- a/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerConfigLoader.java
+++ b/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerConfigLoader.java
@@ -38,6 +38,7 @@ public class ResellerConfigLoader {
       try {
         fileBasedConfiguration = builder.getConfiguration();
       } catch (ConfigurationException e) {
+        System.out.println("Application might not be using config file");
         // ignore the error since the application might not be using config file.
         // log when logging is enabled in the application.
       }

--- a/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerDbManager.java
+++ b/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerDbManager.java
@@ -94,7 +94,6 @@ public class ResellerDbManager {
       String serialNo,
       String customerId) {
     Composite ovh = voucher.getAsComposite(Const.OV_HEADER);
-    UUID guid = ovh.getAsUuid(Const.OVH_GUID);
 
     String sql = ""
         + "MERGE INTO RT_DEVICES  "


### PR DESCRIPTION
 1.In ResellerDbManager, Removing guid variable as it is never
    read after being assigned.

 2.In EpidMaterialService, Removing certRequestInfo variable as it is never
   read after being assigned.

 3.In ResellerConfigLoader, resolving the empty catch
    clause issue by printing an error message.

 4.In EpidMaterialService, resolving the empty catch
    clause issue by printing an error message.

Signed-off-by: Davis Benny <davis.benny@intel.com>