### PR TITLE
Making H2 DB property to allow remote connection runtime configurable.

### DIFF
--- a/demo/manufacturer/manufacturer.env
+++ b/demo/manufacturer/manufacturer.env
@@ -7,3 +7,11 @@ catalina_home=./target/tomcat
 manufacturer_keystore_password=MfgKs@3er
 manufacturer_api_user=apiUser
 manufacturer_api_password=MfgApiPass123
+# These properties allow remote connection to H2 DB. The properties 'webAllowOther' and
+# 'tcpAllowOthers' create a security hole in the system. Not recommended for use on production
+# system.
+# To enable remote connection change the properties to:
+# webAllowOthers=true
+# db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort ${manufacturer_database_port}
+webAllowOthers=false
+db.tcpServer=-tcp -ifNotExists -tcpPort ${manufacturer_database_port}

--- a/demo/owner/owner.env
+++ b/demo/owner/owner.env
@@ -13,3 +13,11 @@ owner_svi_values=./serviceinfo/sample-values
 owner_svi_string=./serviceinfo/sample-svi.csv
 owner_api_user=apiUser
 owner_api_password=OwnerApiPass123
+# These properties allow remote connection to H2 DB. The properties 'webAllowOther' and
+# 'tcpAllowOthers' create a security hole in the system. Not recommended for use on production
+# system.
+# To enable remote connection change the properties to:
+# webAllowOthers=true
+# db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort ${owner_database_port}
+webAllowOthers=false
+db.tcpServer=-tcp -ifNotExists -tcpPort ${owner_database_port}

--- a/demo/reseller/reseller.env
+++ b/demo/reseller/reseller.env
@@ -9,3 +9,11 @@ reseller_keystore_password=RsrKs@3er
 reseller_database_driver=org.h2.Driver
 reseller_api_user=admin
 reseller_api_password=test
+# These properties allow remote connection to H2 DB. The properties 'webAllowOther' and
+# 'tcpAllowOthers' create a security hole in the system. Not recommended for use on production
+# system.
+# To enable remote connection change the properties to:
+# webAllowOthers=true
+# db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort ${reseller_database_port}
+webAllowOthers=false
+db.tcpServer=-tcp -ifNotExists -tcpPort ${reseller_database_port}

--- a/demo/rv/rv.env
+++ b/demo/rv/rv.env
@@ -5,3 +5,11 @@ rv_database_password=
 rv_database_port=8050
 #epid_online_url=https://verify.epid-sbx.trustedservices.intel.com/
 catalina_home=./target/tomcat
+# These properties allow remote connection to H2 DB. The properties 'webAllowOther' and
+# 'tcpAllowOthers' create a security hole in the system. Not recommended for use on production
+# system.
+# To enable remote connection change the properties to:
+# webAllowOthers=true
+# db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort ${rv_database_port}
+webAllowOthers=false
+db.tcpServer=-tcp -ifNotExists -tcpPort ${rv_database_port}

--- a/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerApp.java
+++ b/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerApp.java
@@ -69,10 +69,13 @@ public class ManufacturerApp {
         ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.DB_USER));
     ctx.addParameter(ManufacturerAppSettings.DB_PWD,
         ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.DB_PWD));
-    ctx.addParameter("db.tcpServer", "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
-        + ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.DB_PORT));
+    ctx.addParameter(
+        ManufacturerAppSettings.DB_TCP_SERVER,
+        ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.DB_TCP_SERVER));
 
-    ctx.addParameter("webAllowOthers", "true");
+    ctx.addParameter(
+        ManufacturerAppSettings.H2_ALLOW_REMOTE_CONNECTION,
+        ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.H2_ALLOW_REMOTE_CONNECTION));
     ctx.addParameter("trace", "");
 
     ctx.addParameter(ManufacturerAppSettings.MFG_KEYSTORE_PWD,

--- a/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerAppSettings.java
+++ b/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerAppSettings.java
@@ -15,7 +15,9 @@ public class ManufacturerAppSettings {
   public static final String DB_USER = "manufacturer_database_username";
   public static final String DB_PWD = "manufacturer_database_password";
   public static final String DB_PORT = "manufacturer_database_port";
+  public static final String DB_TCP_SERVER = "db.tcpServer";
   public static final String H2_DRIVER = "org.h2.Driver";
+  public static final String H2_ALLOW_REMOTE_CONNECTION = "webAllowOthers";
 
   // tomcat's catalaina.home
   public static final String SERVER_PATH = "catalina_home";

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerAppSettings.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerAppSettings.java
@@ -20,7 +20,9 @@ public class OwnerAppSettings {
   public static final String DB_USER = "owner_database_username";
   public static final String DB_PWD = "owner_database_password";
   public static final String DB_PORT = "owner_database_port";
+  public static final String DB_TCP_SERVER = "db.tcpServer";
   public static final String H2_DRIVER = "org.h2.Driver";
+  public static final String H2_ALLOW_REMOTE_CONNECTION = "webAllowOthers";
 
   // tomcat's catalaina.home
   public static final String SERVER_PATH = "catalina_home";

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
@@ -57,9 +57,12 @@ public class OwnerServerApp {
         OwnerConfigLoader.loadConfig(OwnerAppSettings.DB_PWD));
 
     // hard-coded H2 config
-    ctx.addParameter("db.tcpServer", "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
-        + OwnerConfigLoader.loadConfig(OwnerAppSettings.DB_PORT));
-    ctx.addParameter("webAllowOthers", "true");
+    ctx.addParameter(
+        OwnerAppSettings.DB_TCP_SERVER,
+        OwnerConfigLoader.loadConfig(OwnerAppSettings.DB_TCP_SERVER));
+    ctx.addParameter(
+        OwnerAppSettings.H2_ALLOW_REMOTE_CONNECTION,
+        OwnerConfigLoader.loadConfig(OwnerAppSettings.H2_ALLOW_REMOTE_CONNECTION));
     ctx.addParameter("trace", "");
 
     if (null != OwnerConfigLoader.loadConfig(OwnerAppSettings.EPID_URL)) {

--- a/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerAppConstants.java
+++ b/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerAppConstants.java
@@ -13,8 +13,10 @@ public class ResellerAppConstants {
   public static final String DB_PWD = "reseller_database_password";
   public static final String DB_PORT = "reseller_database_port";
   public static final String DB_DRIVER = "reseller_database_driver";
+  public static final String DB_TCP_SERVER = "db.tcpServer";
   public static final String API_USER = "reseller_api_user";
   public static final String API_PWD = "reseller_api_password";
+  public static final String H2_ALLOW_REMOTE_CONNECTION = "webAllowOthers";
 
   // tomcat's catalaina.home
   public static final String SERVER_PATH = "reseller_home";

--- a/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerConfigLoader.java
+++ b/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerConfigLoader.java
@@ -51,11 +51,16 @@ public class ResellerConfigLoader {
       defaultConfiguration.addProperty(ResellerAppConstants.DB_USER, "sa");
       defaultConfiguration.addProperty(ResellerAppConstants.DB_PWD, "");
       defaultConfiguration.addProperty(ResellerAppConstants.DB_PORT, "8071");
+      defaultConfiguration.addProperty(
+          ResellerAppConstants.DB_TCP_SERVER,
+          "-tcp -ifNotExists -tcpPort "
+              + defaultConfiguration.getProperty(ResellerAppConstants.DB_PORT));
       defaultConfiguration.addProperty(ResellerAppConstants.KEYSTORE_TYPE, "PKCS11");
       defaultConfiguration.addProperty(ResellerAppConstants.KEYSTORE_PATH, "");
       defaultConfiguration.addProperty(ResellerAppConstants.KEYSTORE_PWD, "RsrKs@3er");
       defaultConfiguration.addProperty(ResellerAppConstants.API_USER, "admin");
       defaultConfiguration.addProperty(ResellerAppConstants.API_PWD, "test");
+      defaultConfiguration.addProperty(ResellerAppConstants.H2_ALLOW_REMOTE_CONNECTION, false);
 
       final String url = "jdbc:h2:tcp://localhost:8071/"
           + Path.of(System.getProperty(ResellerAppConstants.USER_DIR),

--- a/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerServerApp.java
+++ b/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerServerApp.java
@@ -51,9 +51,12 @@ public class ResellerServerApp {
         ResellerConfigLoader.loadConfig(ResellerAppConstants.DB_DRIVER));
 
     // hard-coded H2 config
-    ctx.addParameter("db.tcpServer", "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
-        + ResellerConfigLoader.loadConfig(ResellerAppConstants.DB_PORT));
-    ctx.addParameter("webAllowOthers", "true");
+    ctx.addParameter(
+        ResellerAppConstants.DB_TCP_SERVER,
+        ResellerConfigLoader.loadConfig(ResellerAppConstants.DB_TCP_SERVER));
+    ctx.addParameter(
+        ResellerAppConstants.H2_ALLOW_REMOTE_CONNECTION,
+        ResellerConfigLoader.loadConfig(ResellerAppConstants.H2_ALLOW_REMOTE_CONNECTION));
     ctx.addParameter("trace", "");
 
     ctx.addParameter(ResellerAppConstants.KEYSTORE_PWD,

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvAppSettings.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvAppSettings.java
@@ -13,7 +13,9 @@ public class RvAppSettings {
   public static final String DB_USER = "rv_database_username";
   public static final String DB_PWD = "rv_database_password";
   public static final String DB_PORT = "rv_database_port";
+  public static final String DB_TCP_SERVER = "db.tcpServer";
   public static final String H2_DRIVER = "org.h2.Driver";
+  public static final String H2_ALLOW_REMOTE_CONNECTION = "webAllowOthers";
 
   // tomcat's catalaina.home
   public static final String SERVER_PATH = "catalina_home";

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
@@ -39,11 +39,11 @@ public class RvServerApp {
     ctx.addParameter(RvAppSettings.DB_USER, RvConfigLoader.loadConfig(RvAppSettings.DB_USER));
     ctx.addParameter(RvAppSettings.DB_PWD, RvConfigLoader.loadConfig(RvAppSettings.DB_PWD));
     ctx.addParameter(
-        "db.tcpServer",
-        "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
-            + RvConfigLoader.loadConfig(RvAppSettings.DB_PORT));
+        RvAppSettings.DB_TCP_SERVER, RvConfigLoader.loadConfig(RvAppSettings.DB_TCP_SERVER));
 
-    ctx.addParameter("webAllowOthers", "true");
+    ctx.addParameter(
+        RvAppSettings.H2_ALLOW_REMOTE_CONNECTION,
+        RvConfigLoader.loadConfig(RvAppSettings.H2_ALLOW_REMOTE_CONNECTION));
     ctx.addParameter("trace", "");
     if (null != RvConfigLoader.loadConfig(RvAppSettings.EPID_URL)) {
       ctx.addParameter(RvAppSettings.EPID_URL, RvConfigLoader.loadConfig(RvAppSettings.EPID_URL));


### PR DESCRIPTION
- Properties `webAllowOthers` and `tcpAllowOthers` create a security hole in the system. Not recommended to use on production system. These properties have been made runtime configurable to toggle them as required.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>