### PR TITLE
Making remote DB connection to DB disabled by default.

### DIFF
--- a/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerApp.java
+++ b/service/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerApp.java
@@ -69,10 +69,18 @@ public class ManufacturerApp {
         ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.DB_USER));
     ctx.addParameter(ManufacturerAppSettings.DB_PWD,
         ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.DB_PWD));
-    ctx.addParameter("db.tcpServer", "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
+
+    // To enable remote connections to the DB set
+    // db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("db.tcpServer", "-tcp -ifNotExists -tcpPort "
         + ManufacturerConfigLoader.loadConfig(ManufacturerAppSettings.DB_PORT));
 
-    ctx.addParameter("webAllowOthers", "true");
+    // To enable remote connections to the DB set webAllowOthers=true
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("webAllowOthers", "false");
     ctx.addParameter("trace", "");
 
     ctx.addParameter(ManufacturerAppSettings.MFG_KEYSTORE_PWD,

--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
@@ -57,9 +57,17 @@ public class OwnerServerApp {
         OwnerConfigLoader.loadConfig(OwnerAppSettings.DB_PWD));
 
     // hard-coded H2 config
-    ctx.addParameter("db.tcpServer", "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
+    // To enable remote connections to the DB set
+    // db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("db.tcpServer", "-tcp -ifNotExists -tcpPort "
         + OwnerConfigLoader.loadConfig(OwnerAppSettings.DB_PORT));
-    ctx.addParameter("webAllowOthers", "true");
+
+    // To enable remote connections to the DB set webAllowOthers=true
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("webAllowOthers", "false");
     ctx.addParameter("trace", "");
 
     if (null != OwnerConfigLoader.loadConfig(OwnerAppSettings.EPID_URL)) {

--- a/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerServerApp.java
+++ b/service/component-samples/reseller/src/main/java/org/fido/iot/sample/ResellerServerApp.java
@@ -51,9 +51,17 @@ public class ResellerServerApp {
         ResellerConfigLoader.loadConfig(ResellerAppConstants.DB_DRIVER));
 
     // hard-coded H2 config
-    ctx.addParameter("db.tcpServer", "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
+    // To enable remote connections to the DB set
+    // db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("db.tcpServer", "-tcp -ifNotExists -tcpPort "
         + ResellerConfigLoader.loadConfig(ResellerAppConstants.DB_PORT));
-    ctx.addParameter("webAllowOthers", "true");
+
+    // To enable remote connections to the DB set webAllowOthers=true
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("webAllowOthers", "false");
     ctx.addParameter("trace", "");
 
     ctx.addParameter(ResellerAppConstants.KEYSTORE_PWD,

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
@@ -38,12 +38,19 @@ public class RvServerApp {
     ctx.addParameter(RvAppSettings.DB_URL, RvConfigLoader.loadConfig(RvAppSettings.DB_URL));
     ctx.addParameter(RvAppSettings.DB_USER, RvConfigLoader.loadConfig(RvAppSettings.DB_USER));
     ctx.addParameter(RvAppSettings.DB_PWD, RvConfigLoader.loadConfig(RvAppSettings.DB_PWD));
+
+    // To enable remote connections to the DB set
+    // db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
     ctx.addParameter(
         "db.tcpServer",
-        "-tcp -tcpAllowOthers -ifNotExists -tcpPort "
-            + RvConfigLoader.loadConfig(RvAppSettings.DB_PORT));
+        "-tcp -ifNotExists -tcpPort " + RvConfigLoader.loadConfig(RvAppSettings.DB_PORT));
 
-    ctx.addParameter("webAllowOthers", "true");
+    // To enable remote connections to the DB set webAllowOthers=true
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("webAllowOthers", "false");
     ctx.addParameter("trace", "");
     if (null != RvConfigLoader.loadConfig(RvAppSettings.EPID_URL)) {
       ctx.addParameter(RvAppSettings.EPID_URL, RvConfigLoader.loadConfig(RvAppSettings.EPID_URL));

--- a/service/protocol-samples/http-server-di-sample/src/main/java/org/fido/iot/sample/DiApp.java
+++ b/service/protocol-samples/http-server-di-sample/src/main/java/org/fido/iot/sample/DiApp.java
@@ -68,10 +68,18 @@ public class DiApp {
         "jdbc:h2:tcp://" + DB_HOST + ":" + DB_PORT + "/" + DB_PATH);
     ctx.addParameter("db.user", DB_USER);
     ctx.addParameter("db.password", DB_PASSWORD);
-    ctx.addParameter("db.tcpServer",
-        "-tcp -tcpAllowOthers -ifNotExists -tcpPort " + DB_PORT);
 
-    ctx.addParameter("webAllowOthers", "true");
+    // To enable remote connections to the DB set
+    // db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("db.tcpServer",
+        "-tcp -ifNotExists -tcpPort " + DB_PORT);
+
+    // To enable remote connections to the DB set webAllowOthers=true
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("webAllowOthers", "false");
     ctx.addParameter("trace", "");
 
     ctx.addApplicationListener(DbStarter.class.getName());

--- a/service/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fido/iot/sample/To0To1ServerApp.java
+++ b/service/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fido/iot/sample/To0To1ServerApp.java
@@ -45,10 +45,18 @@ public class To0To1ServerApp {
         "jdbc:h2:tcp://" + DB_HOST + ":" + DB_PORT + "/" + DB_PATH);
     ctx.addParameter("db.user", DB_USER);
     ctx.addParameter("db.password", DB_PASSWORD);
-    ctx.addParameter("db.tcpServer",
-        "-tcp -tcpAllowOthers -ifNotExists -tcpPort " + DB_PORT);
 
-    ctx.addParameter("webAllowOthers", "true");
+    // To enable remote connections to the DB set
+    // db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("db.tcpServer",
+        "-tcp -ifNotExists -tcpPort " + DB_PORT);
+
+    // To enable remote connections to the DB set webAllowOthers=true
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("webAllowOthers", "false");
     ctx.addParameter("trace", "");
 
     ctx.addApplicationListener(DbStarter.class.getName());

--- a/service/protocol-samples/http-server-to2-sample/src/main/java/org/fido/iot/sample/To2ServerApp.java
+++ b/service/protocol-samples/http-server-to2-sample/src/main/java/org/fido/iot/sample/To2ServerApp.java
@@ -55,10 +55,18 @@ public class To2ServerApp {
         "jdbc:h2:tcp://" + DB_HOST + ":" + DB_PORT + "/" + DB_PATH);
     ctx.addParameter("db.user", DB_USER);
     ctx.addParameter("db.password", DB_PASSWORD);
-    ctx.addParameter("db.tcpServer",
-        "-tcp -tcpAllowOthers -ifNotExists -tcpPort " + DB_PORT);
 
-    ctx.addParameter("webAllowOthers", "true");
+    // To enable remote connections to the DB set
+    // db.tcpServer=-tcp -tcpAllowOthers -ifNotExists -tcpPort
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("db.tcpServer",
+        "-tcp -ifNotExists -tcpPort " + DB_PORT);
+
+    // To enable remote connections to the DB set webAllowOthers=true
+    // This creates a security hole in the system.
+    // Not recommended to use especially on production system
+    ctx.addParameter("webAllowOthers", "false");
     ctx.addParameter("trace", "");
 
     ctx.addApplicationListener(DbStarter.class.getName());


### PR DESCRIPTION
- Properties `webAllowOthers` and `tcpAllowOthers` allow remote connections to the DB,
While doing so they create a security hole in the system. Not recommended to use on
production system. So remote connection to DB has been made disabled by
default.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>