### PR TITLE
rv: Add option to set test mode for EPID

### DIFF
--- a/demo/rv/rv.env
+++ b/demo/rv/rv.env
@@ -4,4 +4,5 @@ rv_database_username=sa
 rv_database_password=
 rv_database_port=8050
 #epid_online_url=https://verify.epid-sbx.trustedservices.intel.com/
+#epid_test_mode=false
 catalina_home=./target/tomcat

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvAppSettings.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvAppSettings.java
@@ -20,4 +20,5 @@ public class RvAppSettings {
 
   // EPID URL
   public static final String EPID_URL = "epid_online_url";
+  public static final String EPID_TEST_MODE = "epid_test_mode";
 }

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvContextListener.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvContextListener.java
@@ -45,6 +45,18 @@ public class RvContextListener implements ServletContextListener {
     ds.setMaxOpenPreparedStatements(100);
 
     final CryptoService cs = new CryptoService();
+    String epidTestMode = sc.getInitParameter(RvAppSettings.EPID_TEST_MODE);
+    if (null != epidTestMode && Boolean.valueOf(epidTestMode)) {
+      cs.setEpidTestMode();
+      sc.log("EPID Test mode enabled.");
+    }
+    String epidUrl = sc.getInitParameter(RvAppSettings.EPID_URL);
+    if (null != epidUrl) {
+      EpidUtils.setEpidOnlineUrl(epidUrl);
+    } else {
+      sc.log("EPID URL not set. Default URL will be used: "
+              + EpidUtils.getEpidOnlineUrl().toString());
+    }
 
     sc.setAttribute("datasource", ds);
     sc.setAttribute("cryptoservice", cs);
@@ -85,10 +97,7 @@ public class RvContextListener implements ServletContextListener {
           }
         };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);
-    String epidUrl = sc.getInitParameter(RvAppSettings.EPID_URL);
-    if (null != epidUrl) {
-      EpidUtils.setEpidOnlineUrl(epidUrl);
-    }
+
     // create tables
     RvsDbManager manager = new RvsDbManager();
     manager.createTables(ds);

--- a/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
+++ b/service/component-samples/rv/src/main/java/org/fido/iot/sample/RvServerApp.java
@@ -55,6 +55,10 @@ public class RvServerApp {
     if (null != RvConfigLoader.loadConfig(RvAppSettings.EPID_URL)) {
       ctx.addParameter(RvAppSettings.EPID_URL, RvConfigLoader.loadConfig(RvAppSettings.EPID_URL));
     }
+    if (null != RvConfigLoader.loadConfig(RvAppSettings.EPID_TEST_MODE)) {
+      ctx.addParameter(RvAppSettings.EPID_TEST_MODE,
+              RvConfigLoader.loadConfig(RvAppSettings.EPID_TEST_MODE));
+    }
 
     ctx.addApplicationListener(DbStarter.class.getName());
     ctx.addApplicationListener(RvContextListener.class.getName());


### PR DESCRIPTION
Making EPID test mode configurable in RV component sample to
allow ease in toggling.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>