### PR TITLE
Owner API Addition: API to update Device setupinfo

### DIFF
--- a/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
+++ b/service/component-samples/owner/src/main/java/org/fido/iot/sample/OwnerServerApp.java
@@ -12,6 +12,7 @@ import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.apache.tomcat.util.descriptor.web.SecurityCollection;
 import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
 import org.fido.iot.api.OwnerServiceInfoValuesServlet;
+import org.fido.iot.api.OwnerSetupInfoServlet;
 import org.fido.iot.api.OwnerSviServlet;
 import org.fido.iot.api.OwnerVoucherServlet;
 import org.fido.iot.protocol.Const;
@@ -116,6 +117,9 @@ public class OwnerServerApp {
     wrapper = tomcat.addServlet(ctx, "sviServlet",
         new OwnerSviServlet());
     wrapper.addMapping("/api/v1/owner/svi/*");
+    wrapper = tomcat.addServlet(ctx, "setupinfoServlet",
+        new OwnerSetupInfoServlet());
+    wrapper.addMapping("/api/v1/owner/setupinfo/*");
     wrapper.setAsyncSupported(true);
 
     wrapper = tomcat.addServlet(ctx, "H2Console", new WebServlet());

--- a/service/http-api-samples/http-api-owner-sample/src/main/java/org/fido/iot/api/OwnerSetupInfoServlet.java
+++ b/service/http-api-samples/http-api-owner-sample/src/main/java/org/fido/iot/api/OwnerSetupInfoServlet.java
@@ -1,0 +1,94 @@
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package org.fido.iot.api;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import org.fido.iot.protocol.Const;
+import org.fido.iot.storage.OwnerDbManager;
+
+public class OwnerSetupInfoServlet extends HttpServlet {
+
+  private static final String SETUPINFO_GUID = "guid";
+  private static final String SETUPINFO_RVINFO = "rvinfo";
+  private static final String SETUPINFO_ARRAY_DELIMETER = ",";
+  private static final String SETUPINFO_VALUE_DELIMETER = ":=";
+
+  @Override
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    if (req.getContentType().compareToIgnoreCase("application/text") != 0) {
+      resp.setStatus(Const.HTTP_UNSUPPORTED_MEDIA_TYPE);
+      return;
+    }
+
+    String guid = req.getParameter("id");
+    if (guid == null) {
+      getServletContext().log("No current GUID has been provided to update.");
+      resp.setStatus(400);
+      return;
+    }
+    UUID currentGuid = null;
+    try {
+      currentGuid = UUID.fromString(guid);
+    } catch (IllegalArgumentException e) {
+      getServletContext().log("Invalid current GUID has been provided to update.");
+      resp.setStatus(400);
+      return;
+    }
+
+    try {
+      String requestBody = req.getReader().lines().collect(Collectors.joining());
+
+      // Request format: guid==<guid>,rvinfo==<rvinfo>
+      if (requestBody != null) {
+        DataSource ds = (DataSource) getServletContext().getAttribute("datasource");
+        OwnerDbManager ownerDbManager = new OwnerDbManager();
+
+        String[] setupInfos = requestBody.split(SETUPINFO_ARRAY_DELIMETER);
+        if (setupInfos.length > 2) {
+          getServletContext().log("Invalid setupinfo request has been provided.");
+          resp.setStatus(400);
+          return;
+        }
+        UUID replacementGuid = null;
+        String replacementRvInfo = null;
+        for (String setupInfo : setupInfos) {
+          String[] si = setupInfo.split(SETUPINFO_VALUE_DELIMETER);
+          if (si.length == 2) {
+            switch (si[0]) {
+              case SETUPINFO_GUID:
+                replacementGuid = UUID.fromString(si[1]);
+                getServletContext().log("Updating Replacement GUID for " + currentGuid.toString());
+                ownerDbManager.updateDeviceReplacementGuid(ds, currentGuid, replacementGuid);
+                break;
+              case SETUPINFO_RVINFO:
+                replacementRvInfo = si[1];
+                getServletContext()
+                    .log("Updating Replacement Rendezvous Info for " + currentGuid.toString());
+                ownerDbManager.updateDeviceReplacementRvinfo(ds, currentGuid, replacementRvInfo);;
+                break;
+              default:
+                break;
+            }
+          } else {
+            getServletContext().log("Invalid setupinfo request has been provided.");
+            resp.setStatus(400);
+            return;
+          }
+        }
+      }
+    } catch (Exception exp) {
+      getServletContext().log("Error occurred while updating setupinfo. " + exp.getMessage());
+      resp.setStatus(Const.HTTP_INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbManager.java
+++ b/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbManager.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import org.fido.iot.protocol.Composite;
 import org.fido.iot.protocol.Const;
 import org.fido.iot.protocol.MessageBodyException;
+import org.fido.iot.protocol.RendezvousInfoDecoder;
 import org.fido.iot.serviceinfo.SdoSys;
 
 /**
@@ -324,6 +325,53 @@ public class OwnerDbManager {
       assignSviToDevice(ds, guid, Files.readString(svi));
     } catch (IOException e) {
       System.out.println("Unable to load sample service info");
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Update the replacementRvInfo for given currentGuid.
+   *
+   * @param ds Datasource instance
+   * @param currentGuid The GUID of the device for which updates need to be made.
+   * @param replacementRvInfo The replacement/new RvInfo for the device.
+   */
+  public void updateDeviceReplacementRvinfo(DataSource ds, UUID currentGuid,
+      String replacementRvInfo) {
+
+    String sql = "UPDATE TO2_DEVICES"
+        + " SET REPLACEMENT_RVINFO = ?"
+        + " WHERE GUID = ?;";
+
+    try (Connection conn = ds.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+      pstmt.setBytes(1, RendezvousInfoDecoder.decode(replacementRvInfo).toBytes());
+      pstmt.setString(2, currentGuid.toString());
+      pstmt.executeUpdate();
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Update the replacementGuid for given currentGuid.
+   *
+   * @param ds Datasource instance
+   * @param currentGuid The GUID of the device for which updates need to be made.
+   * @param replacementGuid The replacement/new GUID for the device.
+   */
+  public void updateDeviceReplacementGuid(DataSource ds, UUID currentGuid, UUID replacementGuid) {
+
+    String sql = "UPDATE TO2_DEVICES"
+        + " SET REPLACEMENT_GUID = ?"
+        + " WHERE GUID = ?;";
+
+    try (Connection conn = ds.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+      pstmt.setString(1, replacementGuid.toString());
+      pstmt.setString(2, currentGuid.toString());
+      pstmt.executeUpdate();
+    } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
- Added an API that updates the Device Setup info (replacement GUID,
RVInfo). Request body is off the form:
guid:=<guid>,rvinfo:=<rvinfo>
where ':=' is value delimeter (= is used in RVInfo) and ',' is array delimeter.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>