### PR TITLE
[Fix][component-samples] Owner service heap size configuration.

### DIFF
--- a/demo/owner/owner-entrypoint.sh
+++ b/demo/owner/owner-entrypoint.sh
@@ -6,4 +6,6 @@
 # Sample script that starts the Owner service.
 
 # Start the owner service
-exec java -jar owner.jar
+# Configure heap size based on your requirement.
+# Trying updating heap size to troubleshoot any unexpected errors.
+exec java -Xmx256m -jar owner.jar


### PR DESCRIPTION
Adding argument to configure heap size in owner entrypoint script.

Some heap size issues are observed in the service as the H2 DB size
grows, this can be resolved by increasing heap size. To troubleshoot
any issues encountered due to service heap size, update the it in 
`demo/owner-entrypoint.sh` script. Default is 256MB.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>