### PR TITLE
Fixing the slow nature of Service info transfer

### DIFF
--- a/service/component-samples/http-device-sample/src/main/java/org/fido/iot/sample/Device.java
+++ b/service/component-samples/http-device-sample/src/main/java/org/fido/iot/sample/Device.java
@@ -8,6 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -53,6 +55,7 @@ public class Device {
   private static final String PROPERTY_DI_URL = "fido.iot.url.di";
   private static final String PROPERTY_RANDOMS = "fido.iot.randoms";
   private static final int SERVICEINFO_MTU = 1300;
+  private static boolean isServiceinfoDone;
 
   private static final Logger logger = LogManager.getLogger();
 
@@ -319,22 +322,28 @@ public class Device {
 
       @Override
       public Composite getNextServiceInfo() {
+        if (isServiceinfoDone) {
+          return ServiceInfoEncoder.encodeDeviceServiceInfo(Collections.EMPTY_LIST, false);
+        } else {
+          ServiceInfoMarshaller marshaller = new ServiceInfoMarshaller(
+              SERVICEINFO_MTU,
+              wrappedCreds.get().getAsUuid(Const.DC_GUID));
+          marshaller.register(new DeviceServiceInfoModule());
+          Iterable<Supplier<ServiceInfo>> serviceInfos = marshaller.marshal();
+          List<Composite> marshaledSvi = new LinkedList<>();
 
-        ServiceInfoMarshaller marshaller = new ServiceInfoMarshaller(
-            SERVICEINFO_MTU,
-            wrappedCreds.get().getAsUuid(Const.DC_GUID));
-        marshaller.register(new DeviceServiceInfoModule());
-        Iterable<Supplier<ServiceInfo>> serviceInfos = marshaller.marshal();
-        List<Composite> marshaledSvi = new LinkedList<>();
-
-        for (Supplier<ServiceInfo> supplier : serviceInfos) {
-          ServiceInfo si = supplier.get();
-          for (ServiceInfoEntry sie : si) {
-            Composite c = ServiceInfoEncoder.encodeValue(sie.getKey(), sie.getValue().getContent());
-            marshaledSvi.add(c);
+          for (Supplier<ServiceInfo> supplier : serviceInfos) {
+            ServiceInfo si = supplier.get();
+            for (ServiceInfoEntry sie : si) {
+              Composite c = ServiceInfoEncoder.encodeValue(
+                  sie.getKey(), sie.getValue().getContent());
+              marshaledSvi.add(c);
+            }
           }
+          // As per the default MTU, only one message is sent to the Owner as Serviceinfo.
+          isServiceinfoDone = true;
+          return ServiceInfoEncoder.encodeDeviceServiceInfo(marshaledSvi, false);
         }
-        return ServiceInfoEncoder.encodeDeviceServiceInfo(marshaledSvi, false);
       }
 
       @Override
@@ -362,7 +371,6 @@ public class Device {
 
       @Override
       public void prepareServiceInfo() {
-
       }
 
       @Override

--- a/serviceinfo/src/main/java/org/fido/iot/serviceinfo/ServiceInfoEntry.java
+++ b/serviceinfo/src/main/java/org/fido/iot/serviceinfo/ServiceInfoEntry.java
@@ -3,6 +3,7 @@
 
 package org.fido.iot.serviceinfo;
 
+import java.io.Serializable;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Map.Entry;
 

--- a/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbManager.java
+++ b/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerDbManager.java
@@ -76,6 +76,7 @@ public class OwnerDbManager {
           + "SIGINFOA BLOB, "
           + "SERVICEINFO_COUNT BIGINT, "
           + "SERVICEINFO_POSITION BIGINT, "
+          + "SERVICEINFO_BLOB BLOB, "
           + "CREATED TIMESTAMP,"
           + "UPDATED TIMESTAMP,"
           + "PRIMARY KEY (SESSION_ID), "

--- a/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerServiceInfoSequence.java
+++ b/storage/storage-samples/storage-owner-sample/src/main/java/org/fido/iot/storage/OwnerServiceInfoSequence.java
@@ -50,10 +50,10 @@ public class OwnerServiceInfoSequence extends ServiceInfoSequence {
       pstmt.setString(1, getServiceInfoId());
       try (ResultSet rs = pstmt.executeQuery()) {
         while (rs.next()) {
-          InputStream inputStream = rs.getBinaryStream(1);
-          inputStream.skip(getStart());
+          InputStream inputStream = rs.getBlob(1).getBinaryStream(getStart() + 1, lengthToRead);
           byte[] content = new byte[lengthToRead];
           inputStream.read(content, 0, lengthToRead);
+          inputStream.close();
           return content;
         }
       } catch (IOException e) {


### PR DESCRIPTION
- The earlier approach created the servieinfo messages from the start
index until the service info that the Owner wishes to send was found,
while iterating over it. This meant that more the number of serviceinfo
messages to be sent, the longer it took to iterate and find the message
owner needed to send.
- In the current approach that fixes the issue, the
'ServiceinfoMarshaller' is serialized/de-serialized to-and-from
database. This allows the Owner to directly find the message and send,
since the Marshaller state is stored, and the iteration to create
messages is completely avoided.
- Additionally, fixing an issue with the Device wherin it sent the same
DeviceServiceinfo message in Type 68 again and again to the owner.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>