### PR TITLE
Fix an issue with TO2Client protocol sample

### DIFF
--- a/service/protocol-samples/http-client-to2-sample/src/main/java/org/fido/iot/sample/To2ClientApp.java
+++ b/service/protocol-samples/http-client-to2-sample/src/main/java/org/fido/iot/sample/To2ClientApp.java
@@ -78,7 +78,8 @@ public class To2ClientApp {
       try {
         WebClient client = new WebClient(path, dr, dispatcher);
         client.run();
-
+        // break here since no exception is thrown, so TO2 is successful.
+        break;
       } catch (Exception e) {
         System.out.println(e.getMessage());
       }


### PR DESCRIPTION
- Fixed an issue where TO2 was being done for all URLs in the RV blob,
regardless of the previous TO2 result.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>