### PR TITLE
Update tomcat version to 9.0.40

### DIFF
--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -25,7 +25,7 @@
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <jackson-datatype-jdk8.version>2.11.0</jackson-datatype-jdk8.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcprov.version>1.66</bcprov.version>
     <bcpkix.version>1.65</bcpkix.version>
   </properties>

--- a/service/component-samples/manufacturer/pom.xml
+++ b/service/component-samples/manufacturer/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
     <commons.configuration2.version>2.7</commons.configuration2.version>

--- a/service/component-samples/owner/pom.xml
+++ b/service/component-samples/owner/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
     <commons.configuration2.version>2.7</commons.configuration2.version>

--- a/service/component-samples/reseller/pom.xml
+++ b/service/component-samples/reseller/pom.xml
@@ -23,7 +23,7 @@
     <commons-codec.version>1.14</commons-codec.version>
     <commons.configuration2.version>2.7</commons.configuration2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>

--- a/service/component-samples/rv/pom.xml
+++ b/service/component-samples/rv/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>

--- a/service/http-api-samples/http-api-di-sample/pom.xml
+++ b/service/http-api-samples/http-api-di-sample/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/http-api-samples/http-api-keystore-sample/pom.xml
+++ b/service/http-api-samples/http-api-keystore-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/http-api-samples/http-api-owner-sample/pom.xml
+++ b/service/http-api-samples/http-api-owner-sample/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/http-api-samples/http-api-rv-sample/pom.xml
+++ b/service/http-api-samples/http-api-rv-sample/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/http-dispatchers/http-client-dispatcher/pom.xml
+++ b/service/http-dispatchers/http-client-dispatcher/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/http-dispatchers/http-server-dispatcher/pom.xml
+++ b/service/http-dispatchers/http-server-dispatcher/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcprov.version>1.65.01</bcprov.version>
     <bcpkix.version>1.65</bcpkix.version>
   </properties>

--- a/service/protocol-samples/http-client-di-sample/pom.xml
+++ b/service/protocol-samples/http-client-di-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/protocol-samples/http-client-to0-sample/pom.xml
+++ b/service/protocol-samples/http-client-to0-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/protocol-samples/http-client-to1-sample/pom.xml
+++ b/service/protocol-samples/http-client-to1-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/protocol-samples/http-client-to2-sample/pom.xml
+++ b/service/protocol-samples/http-client-to2-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>

--- a/service/protocol-samples/http-server-di-sample/pom.xml
+++ b/service/protocol-samples/http-server-di-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
     <exec.mainClass>org.fido.iot.sample.DiApp</exec.mainClass>

--- a/service/protocol-samples/http-server-to0-to1-sample/pom.xml
+++ b/service/protocol-samples/http-server-to0-to1-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
     <exec.mainClass>org.fido.iot.sample.To0To1ServerApp</exec.mainClass>

--- a/service/protocol-samples/http-server-to2-sample/pom.xml
+++ b/service/protocol-samples/http-server-to2-sample/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
     <exec.mainClass>org.fido.iot.sample.To2ServerApp</exec.mainClass>

--- a/storage/storage-samples/storage-di-sample/pom.xml
+++ b/storage/storage-samples/storage-di-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcprov.version>1.65.01</bcprov.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>

--- a/storage/storage-samples/storage-owner-sample/pom.xml
+++ b/storage/storage-samples/storage-owner-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcprov.version>1.65.01</bcprov.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>

--- a/storage/storage-samples/storage-rv-sample/pom.xml
+++ b/storage/storage-samples/storage-rv-sample/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.39</tomcat.version>
+    <tomcat.version>9.0.40</tomcat.version>
     <bcpkix.version>1.65</bcpkix.version>
     <dbcp2.version>2.7.0</dbcp2.version>
   </properties>


### PR DESCRIPTION
Updated tomcat version to 9.0.40 to fix known vulnerability
CVE-2020-17527.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>