### PR TITLE
Adding RVBypass support for PRI-device

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ webAllowOthers = true
 
 **IMPORTANT: Not recommended to enable this setting especially on production systems.**
 
+# Enabling Rendezvous Bypass
+
+FIDO Device Onboard includes a Rendezvous Bypass mechanism that is useful for IOT deployments that are not
+dependent on a particular network structure or ownership.
+
+In such cases, a FDO device may elect to bypass the FDO Rendezvous Server mechanism and use
+the local mechanism instead. Since the TO2 provides full authentication and authorization of the
+Device to the Owner, there is no change in the security posture of FDO.
+
+To enable Rendezvous Bypass
+
+- Update the RVInfo blob with `rvbypass` flag  and owner address using the API `POST /api/v1/rvinfo` with
+  `http://<owner-ip:port>?rvbypass=&ipaddress=<owner-ip>&ownerport=<port>` as body.
+
+- Setting the `rvbypass` flag in RVblob, causes the TO1 protocol to be skipped, and a TO2 connection
+ to be attempted to `<owner-ip>` address mentioned in the above POST body.
+
 # EPID Test Mode
 
 EPID devices can be tested using `Test` mode. EPID `Test` mode feature is intended to support onboarding for `development` and `test` devices. Enabling the test mode means signature verification won't be performed for the device. Test mode is enabled by default for protocol-sample in components.

--- a/protocol/src/main/java/org/fido/iot/protocol/Const.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/Const.java
@@ -239,6 +239,7 @@ public final class Const {
   public static final int RV_MEDIUM = 11;
   public static final int RV_PROTOCOL = 12;
   public static final int RV_DELAY_SEC = 13;
+  public static final int RV_BYPASS = 14;
 
   //RVProtocolValue
   public static final int RV_PROT_REST = 0;

--- a/protocol/src/main/java/org/fido/iot/protocol/RendezvousInfoDecoder.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/RendezvousInfoDecoder.java
@@ -42,6 +42,8 @@ public class RendezvousInfoDecoder {
         return new Object[]{Const.RV_DEV_ONLY};
       case "owneronly":
         return new Object[]{Const.RV_OWNER_ONLY};
+      case "rvbypass":
+        return new Object[]{Const.RV_BYPASS};
       case "ipaddress":
         return new Object[]{Const.RV_IP_ADDRESS, getIpAddress(param[1])};
       case "ownerport":

--- a/protocol/src/main/java/org/fido/iot/protocol/To2ClientService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/To2ClientService.java
@@ -29,10 +29,15 @@ public abstract class To2ClientService extends DeviceService {
   protected byte[] nonce7;
   protected byte[] kexA;
   protected Composite ownState;
+  private boolean rvBypass;
 
   protected Enumeration<Composite> dviEnumerator;
 
   protected abstract To2ClientStorage getStorage();
+
+  public void setRvBypass(boolean rvBypass) {
+    this.rvBypass = rvBypass;
+  }
 
   protected Composite getVoucherHeader() {
     return voucherHdr;
@@ -179,7 +184,10 @@ public abstract class To2ClientService extends DeviceService {
     PublicKey verifyKey = getCryptoService().decode(pub);
     getCryptoService().verify(verifyKey, cose, null);
 
-    //TODO: verify to1d
+    // Skipping to1d verification, if the RVBypass flag is set.
+    if (!rvBypass) {
+      //TODO: verify to1d
+    }
 
     //calculate and set hdrHash
     byte[] guid = ovh.getAsBytes(Const.OVH_GUID);

--- a/service/component-samples/http-device-sample/src/main/java/org/fido/iot/sample/Device.java
+++ b/service/component-samples/http-device-sample/src/main/java/org/fido/iot/sample/Device.java
@@ -236,7 +236,7 @@ public class Device {
 
     rvBypass = isRvBypassSet(rvi);
     if (!rvBypass) {
-      // if rvBypass flag is not set, continue with T01.
+      logger.info("RVBypass flag not set, Starting TO1.");
 
       List<String> to1Urls = RendezvousInfoDecoder.getHttpDirectives(rvi, Const.RV_DEV_ONLY);
       To1ClientStorage to1Storage = new To1ClientStorage() {


### PR DESCRIPTION
   Adding RVBypass support for PRI-device.

   RVBypass Scenario:

    1. When RVBypass flag is set in RVinfo;
    the client skips T01 and proceeds with T02.

    2. And during T02, the client skips Rendezvous blob
    verification.

Signed-off-by: Davis Benny <davis.benny@intel.com>