### PR TITLE
Update KDF to match spec

### DIFF
--- a/protocol/src/main/java/org/fido/iot/protocol/Const.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/Const.java
@@ -404,10 +404,10 @@ public final class Const {
   public static final String KEY_EXCHANGE_A = "A";
   public static final String KEY_EXCHANGE_B = "B";
 
-  public static final byte[] KDF_STRING = "MarshalPointKDF".getBytes(StandardCharsets.US_ASCII);
-  public static final byte[] PROV_CIPHER = "AutomaticProvisioning-cipher"
+  public static final byte[] KDF_STRING = "FIDO-KDF".getBytes(StandardCharsets.US_ASCII);
+  public static final byte[] PROV_CIPHER = "AutomaticOnboard-cipher"
       .getBytes(StandardCharsets.US_ASCII);
-  public static final byte[] PROV_HMAC = "AutomaticProvisioning-hmac"
+  public static final byte[] PROV_HMAC = "AutomaticOnboard-hmac"
       .getBytes(StandardCharsets.US_ASCII);
 
   public static final byte[] HMAC_ZERO = new byte[]{0};

--- a/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
+++ b/protocol/src/main/java/org/fido/iot/protocol/CryptoService.java
@@ -1307,7 +1307,7 @@ public class CryptoService {
   }
 
   protected Composite getSmallerKdf(byte[] shSe) {
-    //HMAC-SHA-256[0,(byte)1||"MarshalPointKDF"||(byte)0||"AutomaticProvisioning-cipher"||ShSe]
+    //HMAC-SHA-256[0,(byte)1||"FIDO-KDF"||(byte)0||"AutomaticOnboard-cipher"||ShSe]
     ByteBuffer buffer = ByteBuffer
         .allocate(1 + Const.KDF_STRING.length + 1 + Const.PROV_CIPHER.length + shSe.length);
     buffer.put((byte) 1);
@@ -1321,7 +1321,7 @@ public class CryptoService {
     byte[] sek = new byte[(Const.BIT_LEN_256 / Byte.SIZE) / 2];//16 bytes
     buffer.get(sek);
 
-    //HMAC-SHA-256[0,(byte)2||"MarshalPointKDF"||(byte)0||"AutomaticProvisioning-hmac"||ShSe]
+    //HMAC-SHA-256[0,(byte)2||"FIDO-KDF"||(byte)0||"AutomaticOnboard-hmac"||ShSe]
     buffer = ByteBuffer
         .allocate(1 + Const.KDF_STRING.length + 1 + Const.PROV_HMAC.length + shSe.length);
 
@@ -1343,7 +1343,7 @@ public class CryptoService {
   }
 
   protected Composite getLargerKdf(byte[] shSe) {
-    //HMAC-SHA-256[0,(byte)1||"MarshalPointKDF"||(byte)0||"AutomaticProvisioning-cipher"||ShSe]
+    //HMAC-SHA-256[0,(byte)1||"FIDO-KDF"||(byte)0||"AutomaticOnboard-cipher"||ShSe]
     ByteBuffer buffer = ByteBuffer
         .allocate(1 + Const.KDF_STRING.length + 1 + Const.PROV_CIPHER.length + shSe.length);
     buffer.put((byte) 1);
@@ -1357,7 +1357,7 @@ public class CryptoService {
     byte[] sek = new byte[Const.BIT_LEN_256 / Byte.SIZE]; // 32 bytes
     buffer.get(sek);
 
-    //HMAC-SHA-256[0,(byte)2||"MarshalPointKDF"||(byte)0||"AutomaticProvisioning-hmac"||ShSe]
+    //HMAC-SHA-256[0,(byte)2||"FIDO-KDF"||(byte)0||"AutomaticOnboard-hmac"||ShSe]
     buffer = ByteBuffer
         .allocate(1 + Const.KDF_STRING.length + 1 + Const.PROV_HMAC.length + shSe.length);
 
@@ -1372,7 +1372,7 @@ public class CryptoService {
     byte[] svk1 = new byte[Const.BIT_LEN_384 / Byte.SIZE]; //48 bytes
     buffer.get(svk1);
 
-    //HMAC-SHA-256[0,(byte)3||"MarshalPointKDF"||(byte)0||"AutomaticProvisioning-hmac"||ShSe]
+    //HMAC-SHA-256[0,(byte)3||"FIDO-KDF"||(byte)0||"AutomaticOnboard-hmac"||ShSe]
     buffer = ByteBuffer
         .allocate(1 + Const.KDF_STRING.length + 1 + Const.PROV_HMAC.length + shSe.length);
     buffer.put((byte) 3);


### PR DESCRIPTION
The KDF used in the PRI does not match that
defined by the spec in sections 3.7.1.x.
Update it to match.

Signed-off-by: Greg Bean <greg.bean@intel.com>