### PR TITLE
Adding unit tests to cert-utils

### DIFF
--- a/util/cert-utils/src/test/java/org/fido/iot/certutils/CertTest.java
+++ b/util/cert-utils/src/test/java/org/fido/iot/certutils/CertTest.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache 2.0
 package org.fido.iot.certutils;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.cert.Certificate;
@@ -35,5 +36,16 @@ public class CertTest {
     List<Certificate> certs = PemLoader.loadCerts(ownerKeyPem);
     assertTrue(certs.size() > 0);
 
+  }
+
+  @Test
+  void invalidCert() throws Exception {
+
+    String tamperedCert = ownerKeyPem.replace("e","ee");
+
+    assertThrows(java.lang.RuntimeException.class,
+        ()->{
+          List<Certificate> certs = PemLoader.loadCerts(tamperedCert);
+        });
   }
 }

--- a/util/cert-utils/src/test/java/org/fido/iot/certutils/PrivateKeyTest.java
+++ b/util/cert-utils/src/test/java/org/fido/iot/certutils/PrivateKeyTest.java
@@ -1,0 +1,70 @@
+package org.fido.iot.certutils;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.PrivateKey;
+import org.junit.jupiter.api.Test;
+
+public class PrivateKeyTest {
+
+  String keyPem = "-----BEGIN RSA PRIVATE KEY-----\n"
+      + "MIICXAIBAAKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUp\n"
+      + "wmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ5\n"
+      + "1s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQABAoGAFijko56+qGyN8M0RVyaRAXz++xTqHBLh\n"
+      + "3tx4VgMtrQ+WEgCjhoTwo23KMBAuJGSYnRmoBZM3lMfTKevIkAidPExvYCdm5dYq3XToLkkLv5L2\n"
+      + "pIIVOFMDG+KESnAFV7l2c+cnzRMW0+b6f8mR1CJzZuxVLL6Q02fvLi55/mbSYxECQQDeAw6fiIQX\n"
+      + "GukBI4eMZZt4nscy2o12KyYner3VpoeE+Np2q+Z3pvAMd/aNzQ/W9WaI+NRfcxUJrmfPwIGm63il\n"
+      + "AkEAxCL5HQb2bQr4ByorcMWm/hEP2MZzROV73yF41hPsRC9m66KrheO9HPTJuo3/9s5p+sqGxOlF\n"
+      + "L0NDt4SkosjgGwJAFklyR1uZ/wPJjj611cdBcztlPdqoxssQGnh85BzCj/u3WqBpE2vjvyyvyI5k\n"
+      + "X6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl\n"
+      + "U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ\n"
+      + "37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=\n"
+      + "-----END RSA PRIVATE KEY-----";
+
+  String x509CertPem =  "-----BEGIN CERTIFICATE-----\n"
+      + "MIIB9DCCAZmgAwIBAgIJANpFH5JBylZhMAoGCCqGSM49BAMCMGoxJjAkBgNVBAMM\n"
+      + "HVNkbyBEZW1vIE93bmVyIFJvb3QgQXV0aG9yaXR5MQ8wDQYDVQQIDAZPcmVnb24x\n"
+      + "EjAQBgNVBAcMCUhpbGxzYm9ybzELMAkGA1UEBhMCVVMxDjAMBgNVBAoMBUludGVs\n"
+      + "MCAXDTE5MTAxMDE3Mjk0NFoYDzIwNTQxMDAxMTcyOTQ0WjBqMSYwJAYDVQQDDB1T\n"
+      + "ZG8gRGVtbyBPd25lciBSb290IEF1dGhvcml0eTEPMA0GA1UECAwGT3JlZ29uMRIw\n"
+      + "EAYDVQQHDAlIaWxsc2Jvcm8xCzAJBgNVBAYTAlVTMQ4wDAYDVQQKDAVJbnRlbDBZ\n"
+      + "MBMGByqGSM49AgEGCCqGSM49AwEHA0IABFlVBNhtBi8vLHJgDskMoXAYhf30lHd4\n"
+      + "vzoO1w0oYiW9iLGwmUkardXpNeSG3giOc+wR3mthmRoGiut3Mg9eYDSjJjAkMBIG\n"
+      + "A1UdEwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgIEMAoGCCqGSM49BAMCA0kA\n"
+      + "MEYCIQDrb3b3tigiReIsF+GiImVKJuBsjU6z8mOtlNyfAr7LPAIhAPOl6TaXaasL\n"
+      + "vgML12FQQDT502S6PQPxmB1tRrV2dp8/\n"
+      + "-----END CERTIFICATE-----\n"
+      + "-----BEGIN EC PRIVATE KEY-----\n"
+      + "MHcCAQEEIHg45vhXH9m2SdzNxU55cp94yb962JoNn8F9Zpe6zTNqoAoGCCqGSM49\n"
+      + "AwEHoUQDQgAEWVUE2G0GLy8scmAOyQyhcBiF/fSUd3i/Og7XDShiJb2IsbCZSRqt\n"
+      + "1ek15IbeCI5z7BHea2GZGgaK63cyD15gNA==\n"
+      + "-----END EC PRIVATE KEY-----";
+
+
+  @Test
+  void ValidPrivateKey() throws Exception {
+
+    PrivateKey key = PemLoader.loadPrivateKey(keyPem);
+    assertTrue(key.getAlgorithm() == "RSA");
+
+  }
+
+  @Test
+  void InvalidPrivateKey() throws Exception {
+
+    String tamperedKey = keyPem.replace("e","ee");
+    String tamperedX509Pem = x509CertPem.replace("PRIVATE","PRIVE");
+
+    assertThrows(java.lang.RuntimeException.class,
+        ()->{
+          PrivateKey key = PemLoader.loadPrivateKey(tamperedKey);
+        });
+
+    assertThrows(java.lang.RuntimeException.class,
+        ()->{
+          PrivateKey key = PemLoader.loadPrivateKey(tamperedX509Pem);
+        });
+  }
+
+}

--- a/util/cert-utils/src/test/java/org/fido/iot/certutils/PublicKeyTest.java
+++ b/util/cert-utils/src/test/java/org/fido/iot/certutils/PublicKeyTest.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache 2.0
 package org.fido.iot.certutils;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.PublicKey;
@@ -15,11 +16,45 @@ public class PublicKeyTest {
       + "d3i/Og7XDShiJb2IsbCZSRqt1ek15IbeCI5z7BHea2GZGgaK63cyD15gNA==\n"
       + "-----END PUBLIC KEY-----\n";
 
+  String tamperedX509CertPem =  "-----BEGIN CERTIFICATE-----\n"
+      + "MIIB9DCCAZmgAwIBAgIJANpFH5JBylZhMAoGCCqGSM49BAMCMGoxJjAkBgNVBAMM\n"
+      + "HVNkbyBEZW1vIE93bmVyIFJvb3QgQXV0aG9yaXR5MQ8wDQYDVQQIDAZPcmVnb24x\n"
+      + "EjAQBgNVBAcMCUhpbGxzYm9ybzELMAkGA1UEBhMCVVMxDjAMBgNVBAoMBUludGVs\n"
+      + "MCAXDTE5MTAxMDE3Mjk0NFoYDzIwNTQxMDAxMTcyOTQ0WjBqMSYwJAYDVQQDDB1T\n"
+      + "ZG8gRGVtbyBPd25lciBSb290IEF1dGhvcml0eTEPMA0GA1UECAwGT3JlZ29uMRIw\n"
+      + "EAYDVQQHDAlIaWxsc2Jvcm8xCzAJBgNVBzYTAlVTMQ4wDAYDVQQKDAVJbnRlbDBZ\n"
+      + "MBMGByqGSM49AgEGCCqGSM49AwEHA0IABFlVBNhtBi8vLHJgDskMoXAYhf30lHd4\n"
+      + "vzoO1w0oYiW9iLGwmUkardXpNeSG3giOc+wR3mthmRoGiut3Mg9eYDSjJjAkMBIG\n"
+      + "A1UdEwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgIEMAoGCCqGSM49BAMCA0kA\n"
+      + "MEYCIQDrb3b3tigiReIsF+GiImVKJuBsjU6z8mOtlNyfAr7LPAIhAPOl6TaXaasL\n"
+      + "vgML12FQQDT502S6PQPxmB1tRrV2dp8/\n"
+      + "-----END CERTIFICATE-----\n"
+      + "-----BEGIN EC PUBLIC KEY-----\n"
+      + "MHcCAQEEIHg45vhXH9m2SdzNxU55cp94yb962JoNn8F9Zpe6zTNqoAoGCCqGSM49\n"
+      + "AwEHoUQDQgAEWVUE2G0GLy8scmAOyQyhcBiF/fSUd3i/Og7XDShiJb2IsbCZSRqt\n"
+      + "1ek15IbeCI5z7BHea2GZGgaK63cyD15gNA==\n"
+      + "-----END EC PUBLIC KEY-----";
+
   @Test
   void Test() throws Exception {
 
     List<PublicKey> keys = PemLoader.loadPublicKeys(keysPem);
     assertTrue(keys.size() > 0);
+  }
 
+  @Test
+  void invalidPublicKey() throws Exception {
+
+    String tamperedPublicKey = keysPem.replace("e","ee");
+
+    assertThrows(java.lang.RuntimeException.class,
+        ()->{
+          List<PublicKey> keys = PemLoader.loadPublicKeys(tamperedPublicKey);
+        });
+
+    assertThrows(java.lang.RuntimeException.class,
+        ()->{
+          List<PublicKey> keys = PemLoader.loadPublicKeys(tamperedX509CertPem);
+        });
   }
 }


### PR DESCRIPTION
  Adding unit tests to cert-utils.

  New unit test covers:
   All exception handling structures.
   Functional test on loadPrivateKey() method.

Signed-off-by: Davis Benny <davis.benny@intel.com>