### PR TITLE
Fixing EC384 support

### DIFF
--- a/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerContextListener.java
+++ b/component-samples/manufacturer/src/main/java/org/fido/iot/sample/ManufacturerContextListener.java
@@ -182,7 +182,8 @@ public class ManufacturerContextListener implements ServletContextListener {
               String alias = aliases.next();
               Certificate[] certificateChain = mfgKeyStore.getCertificateChain(alias);
               if (certificateChain != null && certificateChain.length > 0
-                  && certificateChain[0].getPublicKey().getAlgorithm().equals(algName)) {
+                  && certificateChain[0].getPublicKey().getAlgorithm().equals(algName)
+                  && publicKeyType == cs.getPublicKeyType(certificateChain[0].getPublicKey())) {
                 return certificateChain;
               }
             }


### PR DESCRIPTION
PRI Manufacturer was picking up EC256 certificate for the issuer certchain
while creating device ownership voucher for both EC256 and EC384 device
key types. This was resulting in onboarding failure during TO2 due to hash mismatch.
This was happening because in the Manufacturer Storage method `getCertChain`,
only the key algorithm was being checked, which is `ECDH` for both EC256 and EC384
keytypes.

To resolve this issue, an additional check has been added to the
function and the keytype check has been added on top of existing checks
to retrieve the expected certificate.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>