### PR TITLE
Refactoring minimum MTU logging conditions

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
@@ -335,15 +335,14 @@ public abstract class To2ClientService extends DeviceService {
     if (getStorage().getMaxOwnerServiceInfoMtuSz() != null) {
       try {
         ownerMtu = Integer.parseInt(getStorage().getMaxOwnerServiceInfoMtuSz());
-        if (ownerMtu < 0) {
-          System.out.println(
-              "Negative value received. Proceeding with default MTU size of 1300 bytes");
+        if (ownerMtu < Const.DEFAULT_SERVICE_INFO_MTU_SIZE) {
+          System.out.println("Received DeviceMTU size below the threshold value."
+              + " Proceeding with default MTU size of 1300 bytes");
           ownerMtu = Const.DEFAULT_SERVICE_INFO_MTU_SIZE;
-        } else if (ownerMtu >= 0 && ownerMtu < Const.SERVICE_INFO_MTU_MIN_SIZE) {
-          System.out.println(
-              "Received value less than default minimum of 256 bytes. "
-                  + "Updating MTU size to default minimum");
-          ownerMtu = Const.SERVICE_INFO_MTU_MIN_SIZE;
+        } else if (ownerMtu > Const.OWNER_THRESHOLD_DEFAULT_MTU_SIZE) {
+          System.out.println("Received DeviceMTU size above the threshold value."
+              + " Proceeding with maximum MTU size of 8192 bytes");
+          ownerMtu = Const.OWNER_THRESHOLD_DEFAULT_MTU_SIZE;
         }
       } catch (Exception e) {
         System.out.println(

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
@@ -335,11 +335,11 @@ public abstract class To2ClientService extends DeviceService {
     if (getStorage().getMaxOwnerServiceInfoMtuSz() != null) {
       try {
         ownerMtu = Integer.parseInt(getStorage().getMaxOwnerServiceInfoMtuSz());
-        if (ownerMtu <= 0) {
+        if (ownerMtu < 0) {
           System.out.println(
               "Negative value received. Proceeding with default MTU size of 1300 bytes");
           ownerMtu = Const.DEFAULT_SERVICE_INFO_MTU_SIZE;
-        } else if (ownerMtu > 0 && ownerMtu < Const.SERVICE_INFO_MTU_MIN_SIZE) {
+        } else if (ownerMtu >= 0 && ownerMtu < Const.SERVICE_INFO_MTU_MIN_SIZE) {
           System.out.println(
               "Received value less than default minimum of 256 bytes. "
                   + "Updating MTU size to default minimum");

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
@@ -339,10 +339,6 @@ public abstract class To2ClientService extends DeviceService {
           System.out.println("Received DeviceMTU size below the threshold value."
               + " Proceeding with default MTU size of 1300 bytes");
           ownerMtu = Const.DEFAULT_SERVICE_INFO_MTU_SIZE;
-        } else if (ownerMtu > Const.OWNER_THRESHOLD_DEFAULT_MTU_SIZE) {
-          System.out.println("Received DeviceMTU size above the threshold value."
-              + " Proceeding with maximum MTU size of 8192 bytes");
-          ownerMtu = Const.OWNER_THRESHOLD_DEFAULT_MTU_SIZE;
         }
       } catch (Exception e) {
         System.out.println(


### PR DESCRIPTION
  Refactoring minimum MTU logging conditions. Previously,
  even for zero device.mtu.size , the device logged Negative values 
  received. So fixing the check conditions for more accurate logging.

Signed-off-by: Davis Benny <davis.benny@intel.com>