### PR TITLE
Fixing reseller/voucher/* api endpoints

### DIFF
--- a/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerCustomerServlet.java
+++ b/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerCustomerServlet.java
@@ -51,6 +51,10 @@ public class ResellerCustomerServlet extends HttpServlet {
     String uri = req.getRequestURI();
     String serialNo = uri.substring(uri.lastIndexOf('/') + 1);
     DataSource ds = (DataSource) getServletContext().getAttribute("datasource");
-    new ResellerDbManager().deleteKeySet(ds, serialNo);
+    int rowsAffected = new ResellerDbManager().deleteKeySet(ds, serialNo);
+    if (rowsAffected == 0) {
+      resp.setStatus(404);
+      return;
+    }
   }
 }

--- a/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerDbManager.java
+++ b/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerDbManager.java
@@ -167,16 +167,17 @@ public class ResellerDbManager {
    * @param ds Datasource.
    * @param id Customer ID.
    */
-  public void deleteKeySet(DataSource ds, String id) {
+  public int deleteKeySet(DataSource ds, String id) {
     String sql = "DELETE FROM RT_CUSTOMERS WHERE CUSTOMER_ID = ? ";
-
+    int rowsAffected = 0;
     try (Connection conn = ds.getConnection();
         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setInt(1, Integer.parseInt(id));
-      pstmt.executeUpdate();
+      rowsAffected = pstmt.executeUpdate();
 
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
+    return rowsAffected;
   }
 }


### PR DESCRIPTION
  DELETE API call on reseller/voucher/* was returning
  200 OK, even when there is no item to be deleted. So fixing 
  endpoints to return Status 404 when items are not present.

Signed-off-by: Davis Benny <davis.benny@intel.com>