### PR TITLE
Fixing issue with variable mtu.

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ClientService.java
@@ -386,7 +386,8 @@ public abstract class To2ClientService extends DeviceService {
         }
       }
     }
-    getStorage().setMaxDeviceServiceInfoMtuSz(deviceMtu);
+    getStorage()
+        .setMaxDeviceServiceInfoMtuSz(Math.max(deviceMtu, Const.DEFAULT_SERVICE_INFO_MTU_SIZE));
 
     Composite payload = getStorage().getNextServiceInfo();
     body = getCryptoService().encrypt(payload.toBytes(), this.ownState);

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ServerService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ServerService.java
@@ -232,9 +232,7 @@ public abstract class To2ServerService extends MessagingService {
       Composite payload = Composite.newArray();
       payload.set(
           Const.FIRST_KEY,
-          (getStorage()
-              .getMaxDeviceServiceInfoMtuSz()
-              .equals(String.valueOf(Const.DEFAULT_SERVICE_INFO_MTU_SIZE))
+          (getStorage().getMaxDeviceServiceInfoMtuSz() == null
               ? null
               : Integer.parseInt(getStorage().getMaxDeviceServiceInfoMtuSz())));
 


### PR DESCRIPTION
When mtu size is set to zero or negative value in the TO2_SETTINGS
table, TO2 fails with msg/66 giving a null pointer exception.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>