### PR TITLE
Update the version of third-party dependencies

### DIFF
--- a/component-samples/http-device-sample/pom.xml
+++ b/component-samples/http-device-sample/pom.xml
@@ -32,8 +32,8 @@
 
     <bcpkix.version>1.68</bcpkix.version>
     <bcprov.version>1.68</bcprov.version>
-    <junit-jupiter.version>5.7.0-M1</junit-jupiter.version>
-    <log4j.version>2.13.3</log4j.version>
+    <junit-jupiter.version>5.7.1</junit-jupiter.version>
+    <log4j.version>2.14.1</log4j.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>

--- a/component-samples/manufacturer/pom.xml
+++ b/component-samples/manufacturer/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
     <commons.configuration2.version>2.7</commons.configuration2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>

--- a/component-samples/owner/pom.xml
+++ b/component-samples/owner/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
     <commons.configuration2.version>2.7</commons.configuration2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
@@ -97,9 +97,9 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
       <version>${commons.configuration2.version}</version>
-	</dependency>
-	
-	 <dependency>
+    </dependency>
+
+    <dependency>
        <groupId>commons-beanutils</groupId>
        <artifactId>commons-beanutils</artifactId>
        <version>${commons.beanutils.version}</version>

--- a/component-samples/reseller/pom.xml
+++ b/component-samples/reseller/pom.xml
@@ -20,12 +20,12 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <commons.configuration2.version>2.7</commons.configuration2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <exec.mainClass>org.fidoalliance.fdo.sample.ResellerServerApp</exec.mainClass>
   </properties>

--- a/component-samples/rv/pom.xml
+++ b/component-samples/rv/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <commons.configuration2.version>2.7</commons.configuration2.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>

--- a/http-api-samples/http-api-di-sample/pom.xml
+++ b/http-api-samples/http-api-di-sample/pom.xml
@@ -20,10 +20,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/http-api-samples/http-api-keystore-sample/pom.xml
+++ b/http-api-samples/http-api-keystore-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/http-api-samples/http-api-owner-sample/pom.xml
+++ b/http-api-samples/http-api-owner-sample/pom.xml
@@ -20,10 +20,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/http-api-samples/http-api-rv-sample/pom.xml
+++ b/http-api-samples/http-api-rv-sample/pom.xml
@@ -20,10 +20,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   -->
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit-jupiter.version>5.6.1</junit-jupiter.version>
+    <junit-jupiter.version>5.7.1</junit-jupiter.version>
     <slf4j-api.version>1.7.30</slf4j-api.version>
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>

--- a/protocol-samples/http-client-di-sample/pom.xml
+++ b/protocol-samples/http-client-di-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/protocol-samples/http-client-to0-sample/pom.xml
+++ b/protocol-samples/http-client-to0-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/protocol-samples/http-client-to1-sample/pom.xml
+++ b/protocol-samples/http-client-to1-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/protocol-samples/http-client-to2-sample/pom.xml
+++ b/protocol-samples/http-client-to2-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/protocol-samples/http-server-di-sample/pom.xml
+++ b/protocol-samples/http-server-di-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
     <exec.mainClass>org.fidoalliance.fdo.sample.DiApp</exec.mainClass>
   </properties>
 

--- a/protocol-samples/http-server-to0-to1-sample/pom.xml
+++ b/protocol-samples/http-server-to0-to1-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
     <exec.mainClass>org.fidoalliance.fdo.sample.To0To1ServerApp</exec.mainClass>
   </properties>
 

--- a/protocol-samples/http-server-to2-sample/pom.xml
+++ b/protocol-samples/http-server-to2-sample/pom.xml
@@ -20,10 +20,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
     <exec.mainClass>org.fidoalliance.fdo.sample.To2ServerApp</exec.mainClass>
   </properties>
 

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -24,8 +24,8 @@
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
     <jackson-datatype-jdk8.version>2.11.0</jackson-datatype-jdk8.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcprov.version>1.68</bcprov.version>
     <bcpkix.version>1.68</bcpkix.version>
   </properties>

--- a/util/http-dispatchers/http-client-dispatcher/pom.xml
+++ b/util/http-dispatchers/http-client-dispatcher/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/util/http-dispatchers/http-server-dispatcher/pom.xml
+++ b/util/http-dispatchers/http-server-dispatcher/pom.xml
@@ -22,8 +22,8 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcprov.version>1.68</bcprov.version>
     <bcpkix.version>1.68</bcpkix.version>
   </properties>

--- a/util/storage-samples/storage-di-sample/pom.xml
+++ b/util/storage-samples/storage-di-sample/pom.xml
@@ -22,11 +22,11 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcprov.version>1.68</bcprov.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/util/storage-samples/storage-owner-sample/pom.xml
+++ b/util/storage-samples/storage-owner-sample/pom.xml
@@ -22,11 +22,11 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcprov.version>1.68</bcprov.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>

--- a/util/storage-samples/storage-rv-sample/pom.xml
+++ b/util/storage-samples/storage-rv-sample/pom.xml
@@ -22,10 +22,10 @@
 
   <properties>
     <jakson.dataformat.cbor.version>2.11.0</jakson.dataformat.cbor.version>
-    <commons-codec.version>1.14</commons-codec.version>
-    <tomcat.version>9.0.44</tomcat.version>
+    <commons-codec.version>1.15</commons-codec.version>
+    <tomcat.version>9.0.45</tomcat.version>
     <bcpkix.version>1.68</bcpkix.version>
-    <dbcp2.version>2.7.0</dbcp2.version>
+    <dbcp2.version>2.8.0</dbcp2.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The version of following dependencies were updated.

- commons-codec from 1.14 -> 1.15
- commons-dbcp2 from 2.7.0 -> 2.8.0
- junit-jupiter from 5.6.1 -> 5.7.1
- log4j from 2.13.3 -> 2.14.1
- tomcat from 9.0.44 -> 9.0.45

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>