### PR TITLE
Adding check for To0 WaitSeconds in To1 Server.

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To1ServerService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To1ServerService.java
@@ -4,7 +4,9 @@
 package org.fidoalliance.fdo.protocol;
 
 import java.security.PublicKey;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.UUID;
 
 /**
@@ -25,6 +27,14 @@ public abstract class To1ServerService extends MessagingService {
 
       getStorage().setGuid(guid);
 
+      Date expiryTimeStamp = new SimpleDateFormat("yyyy-MM-DD HH:mm:ss.SSS")
+          .parse(getStorage().getExpiryTimeStamp());
+      Date currentTimeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss.SSS")
+          .parse(new SimpleDateFormat("dd.MM.yyyy.HH.mm.ss.SSS").format(new Date()));
+      if (currentTimeStamp.compareTo(expiryTimeStamp) > 0) {
+        throw new RuntimeException("Rv WaitSeconds expired. Perform To0 again");
+      }
+
       byte[] nonceTo1Proof = getCryptoService().getRandomBytes(Const.NONCE16_SIZE);
       getStorage().setNonceTo1Proof(nonceTo1Proof);
       Composite sigA = body.getAsComposite(Const.SECOND_KEY);
@@ -41,7 +51,7 @@ public abstract class To1ServerService extends MessagingService {
 
     } catch (Exception e) {
       getStorage().failed(request, reply);
-      throw e;
+      throw new RuntimeException(e);
     }
   }
 

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To1ServerService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To1ServerService.java
@@ -27,10 +27,10 @@ public abstract class To1ServerService extends MessagingService {
 
       getStorage().setGuid(guid);
 
-      Date expiryTimeStamp = new SimpleDateFormat("yyyy-MM-DD HH:mm:ss.SSS")
-          .parse(getStorage().getExpiryTimeStamp());
-      Date currentTimeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss.SSS")
-          .parse(new SimpleDateFormat("dd.MM.yyyy.HH.mm.ss.SSS").format(new Date()));
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      Date expiryTimeStamp = sdf.parse(getStorage().getExpiryTimeStamp());
+      Date currentTimeStamp = sdf.parse(
+          new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(new Date()));
       if (currentTimeStamp.compareTo(expiryTimeStamp) > 0) {
         throw new RuntimeException("Rv WaitSeconds expired. Perform To0 again");
       }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To1ServerStorage.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To1ServerStorage.java
@@ -30,4 +30,6 @@ public interface To1ServerStorage extends StorageEvents {
   Composite getRedirectBlob();
 
   OnDieService getOnDieService();
+
+  public String getExpiryTimeStamp();
 }

--- a/protocol/src/test/java/org/fidoalliance/fdo/protocol/To1Test.java
+++ b/protocol/src/test/java/org/fidoalliance/fdo/protocol/To1Test.java
@@ -7,6 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.UUID;
 
 import org.fidoalliance.fdo.protocol.ondie.OnDieService;
@@ -141,6 +148,14 @@ public class To1Test extends BaseTemplate {
 
       public OnDieService getOnDieService() {
         return onDieService;
+      }
+
+      @Override
+      public String getExpiryTimeStamp() {
+        Calendar date = Calendar.getInstance();
+        long t = date.getTimeInMillis();
+        Date afterAddingTenMins = new Date(t + (10 * 60000));
+        return (new SimpleDateFormat("yyyy-MM-DD HH:mm:ss.SSS").format(afterAddingTenMins));
       }
 
       @Override

--- a/protocol/src/test/java/org/fidoalliance/fdo/protocol/To1Test.java
+++ b/protocol/src/test/java/org/fidoalliance/fdo/protocol/To1Test.java
@@ -7,18 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
-
+import org.fidoalliance.fdo.certutils.PemLoader;
 import org.fidoalliance.fdo.protocol.ondie.OnDieService;
 import org.junit.jupiter.api.Test;
-import org.fidoalliance.fdo.certutils.PemLoader;
 
 public class To1Test extends BaseTemplate {
 

--- a/util/storage-samples/storage-rv-sample/src/main/java/org/fidoalliance/fdo/storage/To0AllowListDenyListDbStorage.java
+++ b/util/storage-samples/storage-rv-sample/src/main/java/org/fidoalliance/fdo/storage/To0AllowListDenyListDbStorage.java
@@ -113,7 +113,8 @@ public class To0AllowListDenyListDbStorage extends To0DbStorage {
       pstmt.setInt(5, Long.valueOf(requestedWait).intValue());
       Timestamp created = new Timestamp(Calendar.getInstance().getTimeInMillis());
       pstmt.setTimestamp(6, created);
-      Timestamp expiresAt = new Timestamp(Calendar.getInstance().getTimeInMillis() + requestedWait);
+      Timestamp expiresAt = new Timestamp(
+          Calendar.getInstance().getTimeInMillis() + requestedWait * 1000);
       pstmt.setTimestamp(7, expiresAt);
 
       pstmt.executeUpdate();

--- a/util/storage-samples/storage-rv-sample/src/main/java/org/fidoalliance/fdo/storage/To0DbStorage.java
+++ b/util/storage-samples/storage-rv-sample/src/main/java/org/fidoalliance/fdo/storage/To0DbStorage.java
@@ -79,7 +79,8 @@ public class To0DbStorage implements To0ServerStorage {
       pstmt.setInt(5, Long.valueOf(requestedWait).intValue());
       Timestamp created = new Timestamp(Calendar.getInstance().getTimeInMillis());
       pstmt.setTimestamp(6, created);
-      Timestamp expiresAt = new Timestamp(Calendar.getInstance().getTimeInMillis() + requestedWait);
+      Timestamp expiresAt = new Timestamp(
+          Calendar.getInstance().getTimeInMillis() + requestedWait * 1000);
       pstmt.setTimestamp(7, expiresAt);
 
       pstmt.executeUpdate();

--- a/util/storage-samples/storage-rv-sample/src/main/java/org/fidoalliance/fdo/storage/To1DbStorage.java
+++ b/util/storage-samples/storage-rv-sample/src/main/java/org/fidoalliance/fdo/storage/To1DbStorage.java
@@ -110,6 +110,26 @@ public class To1DbStorage implements To1ServerStorage {
   }
 
   @Override
+  public String getExpiryTimeStamp() {
+    String sql = "SELECT EXPIRES_AT FROM RV_REDIRECTS WHERE GUID = ?";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+      pstmt.setString(1, getGuid().toString());
+
+      try (ResultSet rs = pstmt.executeQuery()) {
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    throw new ResourceNotFoundException(getGuid().toString());
+  }
+
+  @Override
   public void starting(Composite request, Composite reply) {
 
   }


### PR DESCRIPTION
The Rendezvous Server should associate GUID with the new owner’s
address information for To0.AcceptOwner.WaitSeconds seconds. Adding
check for the same in To1 Server Service.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>