### PR TITLE
Use a 12-byte IV for GCM

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/CryptoService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/CryptoService.java
@@ -1644,6 +1644,8 @@ public class CryptoService {
       final byte[] iv;
       if (isCtrCipher(cipherName)) {
         iv = state.getAsBytes(Const.THIRD_KEY);
+      } else if (isGcmCipher(cipherName)) { // GCM uses a 12-byte IV
+        iv = getRandomBytes(12);
       } else if (isCcmCipher(cipherName)) { // CCM modes use a 7-byte nonce
         iv = getRandomBytes(7);
       } else { // all other ciphers use a random IV, AES only uses 16 bytes despite key length


### PR DESCRIPTION
Signed-off-by: Greg Bean <greg.bean@intel.com>