### PR TITLE
adjust max read for filewrite

### DIFF
--- a/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerSysModule.java
+++ b/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerSysModule.java
@@ -18,7 +18,11 @@ public class OwnerSysModule implements Module {
 
   private Composite state;
   private final DataSource dataSource;
-  private static final int MAX_READ = 1277;
+  // MAX_READ is set to this value to ensure all known devices
+  // can handle this size of data in the SI.
+  // Future enhancement: adjust this value based on the MTU size
+  // requested by the device.
+  private static final int MAX_READ = 1000;
   private static final byte CBOR_TRUE = (byte) 0xF5;
 
 


### PR DESCRIPTION
This is done to prevent overflow of certain DAL devices

Signed-off-by: johneasterday <john.easterday@intel.com>