### PR TITLE
Fixing ondie path issues

### DIFF
--- a/component-samples/demo/README.md
+++ b/component-samples/demo/README.md
@@ -113,7 +113,7 @@ Note that this requires internet access by the component. Should a component be 
 To enable OnDie support in FDO PRI Manufacturer and FDO PRI Owner, update manufacturer.env and owner.env respectively as below.
 
 ```
-ondie_cache=file:///home/manufacturer/ # file:///home/owner for FDO PRI Owner
+ondie_cache=file:///home/manufacturer/<ondie-folder>/ # file:///home/owner/<ondie-folder>/ for FDO PRI Owner
 ondie_autoupdate=true
 ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
 ondie_check_revocations=false

--- a/component-samples/demo/README.md
+++ b/component-samples/demo/README.md
@@ -118,6 +118,7 @@ Finally, the `ondie_cache` directory needs to be copied into the docker containe
 ```
 COPY ./ondie_cache ./ondie_cache/
 ```
+*For Owner component add `--chown=owner` along with the `COPY` command. Eg: `COPY --chown=owner ./ondie_cache ./ondie_cache/`
 
 `ondie_zip_artifact`: (optional, default = https://tsci.intel.com/content/csme.zip). Specifies the URL of the zip file that contains the OnDie certificates and CRLs.
 

--- a/component-samples/demo/README.md
+++ b/component-samples/demo/README.md
@@ -104,7 +104,20 @@ OnDie requires several certificates and CRLs. These artifacts can be downloaded 
 `ondie_cache`: (required if supporting OnDie, optional otherwise) Specifies the path to the directory containing the OnDie certificates and CRLs.
 
 `ondie_autoupdate`: (optional, default = false) if "true" then the OnDie certificates and CRLs are downloaded from the cloud at start up into the directory specified by ondie_cache.
-Note that this requires internet access by the component. Should a component be run in on-prem mode then this setting should be set to "false". In such cases, the artifacts can be preloaded by running the script in component-sample/scripts/onDieScript.py when access is available or from another machine with access and then copied into the ondie_cache directory.
+Note that this requires internet access by the component.
+
+***NOTE***: If the component is executed in on-prem mode then `ondie_autoupdate` should be set to "false". In such cases, the artifacts can be preloaded by running the script in component-samples/scripts/onDieCache.py.
+Ensure `ondie_cache` directory is present before executing the script.
+
+```
+python3 component-samples/scripts/onDieCache.py --cachedir <path-to-ondie_cache-directory>
+```
+*Requires internet access for the component.
+
+Finally, the `ondie_cache` directory needs to be copied into the docker container, add the following line to `Dockerfile` of Manufacturer and Owner.
+```
+COPY ./ondie_cache ./ondie_cache/
+```
 
 `ondie_zip_artifact`: (optional, default = https://tsci.intel.com/content/csme.zip). Specifies the URL of the zip file that contains the OnDie certificates and CRLs.
 
@@ -113,7 +126,7 @@ Note that this requires internet access by the component. Should a component be 
 To enable OnDie support in FDO PRI Manufacturer and FDO PRI Owner, update manufacturer.env and owner.env respectively as below.
 
 ```
-ondie_cache=file:///home/manufacturer/<ondie-folder>/ # file:///home/owner/<ondie-folder>/ for FDO PRI Owner
+ondie_cache=file:///home/manufacturer/ondie_cache/ # file:///home/owner/ondie_cache/ for FDO PRI Owner
 ondie_autoupdate=true
 ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
 ondie_check_revocations=false

--- a/component-samples/demo/README.md
+++ b/component-samples/demo/README.md
@@ -118,7 +118,7 @@ Finally, the `ondie_cache` directory needs to be copied into the docker containe
 ```
 COPY ./ondie_cache ./ondie_cache/
 ```
-*For Owner component add `--chown=owner` along with the `COPY` command. Eg: `COPY --chown=owner ./ondie_cache ./ondie_cache/`
+*For Owner component, add `--chown=owner` along with the `COPY` command. Eg: `COPY --chown=owner ./ondie_cache ./ondie_cache/`
 
 `ondie_zip_artifact`: (optional, default = https://tsci.intel.com/content/csme.zip). Specifies the URL of the zip file that contains the OnDie certificates and CRLs.
 

--- a/component-samples/scripts/onDieCache.py
+++ b/component-samples/scripts/onDieCache.py
@@ -1,16 +1,23 @@
-#This script copies OnDie ECDSA artifacts from the cloud to a specified local directory.
-#Typically, the FDO components (Mfg, RV, Owner) will be configured to load OnDie certs from this
-#local directory. 
+# This script copies OnDie ECDSA artifacts from the cloud to a specified local directory.
+# Typically, the FDO components (Manufacturer, Owner) will be configured to load OnDie certs from this
+# local directory.
 #
-#When files are updated in the local directory, they will have a file type of ".new". In addition,
-#a touch file is created after copying to indicate to the component than an update has been made.
-#The component will trigger an update when this touch file is detected and will rename the .new 
-#files to the original names as the cache files are read. 
+# When files are updated in the local directory, they will have a file type of ".new". In addition,
+# a touch file is created after copying to indicate to the component than an update has been made.
+# The component will trigger an update when this touch file is detected and will rename the .new
+# files to the original names as the cache files are read.
 #
-#The use of the .new mechanism is employed to prevent any conflict between reading a file and 
-#copying a new version from the script.
+# The use of the .new mechanism is employed to prevent any conflict between reading a file and
+# copying a new version from the script.
 #
-#Use Python version 3.X with this script. This script is not compatible with earlier versions.
+# Use Python version 3.X with this script. This script is not compatible with earlier versions.
+#
+# USAGE:
+# 1. create the ondie_cache folder
+#     mkdir ondie_cache
+# 2. python3 onDieCache.py --cachedir ondie_cache
+# 3. copy the ondie_cache directory to demo/manufacturer and demo/owner.
+
 
 import sys, getopt
 import urllib.request

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/ondie/OnDieCache.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/ondie/OnDieCache.java
@@ -76,7 +76,12 @@ public class OnDieCache {
     if (cacheDir != null) {
       File cache = new File(cacheDir);
       if (!cache.exists()) {
-        throw new IOException("OnDieCertCache: cache directory does not exist: " + cacheDir);
+        if (autoUpdate) {
+          //create cache directory, if the directory does not exist & autoupdate is set to true.
+          cache.mkdir();
+        } else {
+          throw new IOException("OnDieCertCache: cache directory does not exist: " + cacheDir);
+        }
       }
       if (!cache.isDirectory()) {
         throw new IOException("OnDieCertCache: cache directory must be a directory: " + cacheDir);

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/ondie/OnDieCache.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/ondie/OnDieCache.java
@@ -86,6 +86,12 @@ public class OnDieCache {
         // update local cache
         copyFromUrlSources();
       }
+
+      if (Files.exists(Paths.get(cache.getAbsolutePath(), cacheUpdatedTouchFile))) {
+        //if touch file is present; then rename all .new files and remove touch file
+        updateCacheFiles(cache);
+      }
+
       loadCacheMap();
     }
     initialized = true;
@@ -113,7 +119,7 @@ public class OnDieCache {
         if (zipEntry.getName().startsWith("content/OnDieCA")
             && (zipEntry.getName().endsWith(".cer") || zipEntry.getName().endsWith(".crl"))) {
           Path p = Paths.get(zipEntry.getName());
-          File newFile = new File(cacheDir.resolve(p.getFileName().toString()));
+          File newFile = new File(cacheDir.getPath() + p.getFileName().toString());
           FileOutputStream fos = new FileOutputStream(newFile);
           byte[] buffer = new byte[1024];
           int len;
@@ -159,19 +165,24 @@ public class OnDieCache {
       // check for the "files updated" touch file
       if (Files.exists(Paths.get(cache.getAbsolutePath(), cacheUpdatedTouchFile))) {
         // rename all .new files and remove touch file
-        FilenameFilter filter = (dir, name) -> name.endsWith(".new");
-        File[] files = new File(cache.getAbsolutePath()).listFiles(filter);
-        for (File file : files) {
-          File targetFile = new File(file.getAbsolutePath().replaceAll(".new", ""));
-          targetFile.delete();
-          file.renameTo(targetFile);
-          file.delete();
-        }
-        Files.delete(Paths.get(cacheDir.resolve(cacheUpdatedTouchFile)));
+        updateCacheFiles(cache);
         return true;
       }
     }
     return false;
+  }
+
+  private void updateCacheFiles(File cache) throws IOException {
+    // rename all .new files and remove touch file
+    FilenameFilter filter = (dir, name) -> name.endsWith(".new");
+    File[] files = new File(cache.getAbsolutePath()).listFiles(filter);
+    for (File file : files) {
+      File targetFile = new File(file.getAbsolutePath().replaceAll(".new", ""));
+      targetFile.delete();
+      file.renameTo(targetFile);
+      file.delete();
+    }
+    Files.delete(Paths.get(cacheDir.resolve(cacheUpdatedTouchFile)));
   }
 
 


### PR DESCRIPTION
  - Fix to download ondie .crts and .crls into the path specified by
    ondie_cache variable. Previously .crts and .crls were
    downloaded into the _JAVA_EXECUTION_PATH instead of the
    path specified by ondie_cache variable.

  - Fix to strip .new extension from the .crts and .crls files
    downloaded through onDieCache.py script.

Signed-off-by: Davis Benny <davis.benny@intel.com>