### PR TITLE
Add msgid in protocol message logs

### DIFF
--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioCertificateResolver.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioCertificateResolver.java
@@ -15,6 +15,8 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Iterator;
+
+import org.fidoalliance.fdo.loggingutils.LoggerService;
 import org.fidoalliance.fdo.protocol.CloseableKey;
 import org.fidoalliance.fdo.protocol.Const;
 import org.fidoalliance.fdo.protocol.CryptoService;
@@ -29,6 +31,7 @@ public class AioCertificateResolver implements CertificateResolver {
   private final String mfgKeystorePath;
   private final String mfgKeyStorePin;
   private final CryptoService cs;
+  private static final LoggerService logger = new LoggerService(AioCertificateResolver.class);
 
   /**
    * Constructs an instance of a AioCertificateResolver.
@@ -80,7 +83,7 @@ public class AioCertificateResolver implements CertificateResolver {
         }
       } catch (KeyStoreException | UnrecoverableKeyException | NoSuchAlgorithmException
           | CertificateEncodingException e) {
-        System.out.println("Unable to retrieve Private Key. " + e.getMessage());
+        logger.warn("Unable to retrieve Private Key. " + e.getMessage());
       }
     }
     throw new RuntimeException();

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioConfigLoader.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioConfigLoader.java
@@ -10,6 +10,7 @@ import org.apache.commons.configuration2.SystemConfiguration;
 import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.fidoalliance.fdo.loggingutils.LoggerService;
 
 public class AioConfigLoader {
 
@@ -17,6 +18,8 @@ public class AioConfigLoader {
   private static EnvironmentConfiguration environmentConfiguration;
   private static SystemConfiguration systemConfiguration;
   private static FileBasedConfiguration fileBasedConfiguration;
+
+  private static final LoggerService logger = new LoggerService(AioConfigLoader.class);
 
   static {
     environmentConfiguration = new EnvironmentConfiguration();
@@ -32,7 +35,7 @@ public class AioConfigLoader {
         throw new ConfigurationException();
       }
     } catch (ConfigurationException e) {
-      System.out.println("The AIO application might not be using config file");
+      logger.debug("The AIO application might not be using config file.");
       // ignore the error since the application might not be using config file.
       // log when logging is enabled in the application.
     }
@@ -52,7 +55,7 @@ public class AioConfigLoader {
     } else if (null != fileBasedConfiguration && fileBasedConfiguration.containsKey(property)) {
       return fileBasedConfiguration.getString(property);
     }
-    System.out.println("Could not load property: " + property);
+    logger.warn("Could not load property: " + property);
     return null;
   }
 }

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioContextListener.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioContextListener.java
@@ -196,7 +196,7 @@ public class AioContextListener implements ServletContextListener {
       @Override
       protected void replied(Composite reply) {
         String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + reply.toString());
+        logger.debug("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
@@ -211,7 +211,7 @@ public class AioContextListener implements ServletContextListener {
       @Override
       protected void dispatching(Composite request) {
         String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + request.toString());
+        logger.debug("msg/" + msgId + ": " + request.toString());
       }
 
       @Override

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioOwnerKeyResolver.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioOwnerKeyResolver.java
@@ -16,6 +16,8 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Iterator;
+
+import org.fidoalliance.fdo.loggingutils.LoggerService;
 import org.fidoalliance.fdo.protocol.KeyResolver;
 
 public class AioOwnerKeyResolver implements KeyResolver {
@@ -24,6 +26,8 @@ public class AioOwnerKeyResolver implements KeyResolver {
   private final String ownerKeystorePath;
   private final String ownerKeyStoreType;
   private final String ownerKeyStorePin;
+
+  private static final LoggerService logger = new LoggerService(AioOwnerKeyResolver.class);
 
   /**
    * Constructor.
@@ -53,7 +57,7 @@ public class AioOwnerKeyResolver implements KeyResolver {
           }
         }
       } catch (KeyStoreException | UnrecoverableKeyException | NoSuchAlgorithmException e) {
-        System.out.println(e.getMessage());
+        logger.error(e.getMessage());
       }
     }
     return null;
@@ -74,8 +78,8 @@ public class AioOwnerKeyResolver implements KeyResolver {
             ownerKeyStorePin.toCharArray());
       }
     } catch (NoSuchAlgorithmException | CertificateException | IOException | KeyStoreException e) {
-      System.out.println("Keystore not configured.");
-      System.out.println(e.getMessage());
+      logger.error("Keystore not configured.");
+      logger.error(e.getMessage());
     }
   }
 

--- a/component-samples/demo/device/log4j2.xml
+++ b/component-samples/demo/device/log4j2.xml
@@ -3,10 +3,19 @@
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
+        <RollingFile name="FILE" fileName="log" append="true" bufferedIO="true" immediateFlush="true">
+            <filePattern>log-%i</filePattern>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="debug">
-            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="CONSOLE" level="debug"/>
+            <AppenderRef ref="FILE" level="debug"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/component-samples/demo/device/log4j2.xml
+++ b/component-samples/demo/device/log4j2.xml
@@ -1,11 +1,11 @@
-<Configuration status="info">
+<Configuration status="debug">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="CONSOLE"/>
         </Root>
     </Loggers>

--- a/component-samples/demo/manufacturer/log4j2.xml
+++ b/component-samples/demo/manufacturer/log4j2.xml
@@ -3,10 +3,19 @@
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
+        <RollingFile name="FILE" fileName="log" append="true" bufferedIO="true" immediateFlush="true">
+            <filePattern>log-%i</filePattern>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="debug">
-            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="CONSOLE" level="debug"/>
+            <AppenderRef ref="FILE" level="debug"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/component-samples/demo/manufacturer/log4j2.xml
+++ b/component-samples/demo/manufacturer/log4j2.xml
@@ -1,11 +1,11 @@
-<Configuration status="info">
+<Configuration status="debug">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="CONSOLE"/>
         </Root>
     </Loggers>

--- a/component-samples/demo/owner/log4j2.xml
+++ b/component-samples/demo/owner/log4j2.xml
@@ -3,10 +3,19 @@
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
+        <RollingFile name="FILE" fileName="log" append="true" bufferedIO="true" immediateFlush="true">
+            <filePattern>log-%i</filePattern>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="debug">
-            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="CONSOLE" level="debug"/>
+            <AppenderRef ref="FILE" level="debug"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/component-samples/demo/owner/log4j2.xml
+++ b/component-samples/demo/owner/log4j2.xml
@@ -1,11 +1,11 @@
-<Configuration status="info">
+<Configuration status="debug">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="CONSOLE"/>
         </Root>
     </Loggers>

--- a/component-samples/demo/reseller/log4j2.xml
+++ b/component-samples/demo/reseller/log4j2.xml
@@ -3,10 +3,19 @@
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
+        <RollingFile name="FILE" fileName="log" append="true" bufferedIO="true" immediateFlush="true">
+            <filePattern>log-%i</filePattern>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="debug">
-            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="CONSOLE" level="debug"/>
+            <AppenderRef ref="FILE" level="debug"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/component-samples/demo/reseller/log4j2.xml
+++ b/component-samples/demo/reseller/log4j2.xml
@@ -1,11 +1,11 @@
-<Configuration status="info">
+<Configuration status="debug">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="CONSOLE"/>
         </Root>
     </Loggers>

--- a/component-samples/demo/rv/log4j2.xml
+++ b/component-samples/demo/rv/log4j2.xml
@@ -3,10 +3,19 @@
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
+        <RollingFile name="FILE" fileName="log" append="true" bufferedIO="true" immediateFlush="true">
+            <filePattern>log-%i</filePattern>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="debug">
-            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="CONSOLE" level="debug"/>
+            <AppenderRef ref="FILE" level="debug"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/component-samples/demo/rv/log4j2.xml
+++ b/component-samples/demo/rv/log4j2.xml
@@ -1,11 +1,11 @@
-<Configuration status="info">
+<Configuration status="debug">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="CONSOLE"/>
         </Root>
     </Loggers>

--- a/component-samples/manufacturer/src/main/java/org/fidoalliance/fdo/sample/ManufacturerContextListener.java
+++ b/component-samples/manufacturer/src/main/java/org/fidoalliance/fdo/sample/ManufacturerContextListener.java
@@ -172,13 +172,13 @@ public class ManufacturerContextListener implements ServletContextListener {
       @Override
       protected void replied(Composite reply) {
         String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + reply.toString());
+        logger.debug("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
         String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + request.toString());
+        logger.debug("msg/" + msgId + ": " + request.toString());
       }
 
       @Override

--- a/component-samples/manufacturer/src/main/java/org/fidoalliance/fdo/sample/ManufacturerContextListener.java
+++ b/component-samples/manufacturer/src/main/java/org/fidoalliance/fdo/sample/ManufacturerContextListener.java
@@ -171,21 +171,23 @@ public class ManufacturerContextListener implements ServletContextListener {
 
       @Override
       protected void replied(Composite reply) {
-        sc.log("replied with: " + reply.toString());
+        String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
-        sc.log("dispatching: " + request.toString());
+        String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + request.toString());
       }
 
       @Override
       protected void failed(Exception e) {
         StringWriter writer = new StringWriter();
         try (PrintWriter pw = new PrintWriter(writer)) {
-          sc.log(e.getMessage());
+          logger.warn(e.getMessage());
         }
-        sc.log(writer.toString());
+        logger.warn(writer.toString());
       }
     };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);
@@ -200,17 +202,17 @@ public class ManufacturerContextListener implements ServletContextListener {
               sc.getInitParameter(ManufacturerAppSettings.OWNER_PUB_KEY_PATH)));
       manager.addCustomer(ds, 1, "owner", ownerKeysPem);
       manager.setAutoEnroll(ds, 1);
-      System.out.println("Registered public keys for customer 'owner'");
+      logger.info("Registered public keys for customer 'owner'");
     } catch (IOException e) {
-      System.out.println("No default public keys found for customer 'owner'");
+      logger.info("No default public keys found for customer 'owner'");
     }
     try {
       final String resellerKeysPem = Files.readString(Paths.get(
               sc.getInitParameter(ManufacturerAppSettings.RESELLER_PUB_KEY_PATH)));
       manager.addCustomer(ds, 2, "reseller", resellerKeysPem);
-      System.out.println("Registered public keys for customer 'reseller'");
+      logger.info("Registered public keys for customer 'reseller'");
     } catch (IOException e) {
-      System.out.println("No default public keys found for customer 'reseller'");
+      logger.info("No default public keys found for customer 'reseller'");
     }
 
   }

--- a/component-samples/owner/src/main/java/org/fidoalliance/fdo/sample/OwnerContextListener.java
+++ b/component-samples/owner/src/main/java/org/fidoalliance/fdo/sample/OwnerContextListener.java
@@ -166,13 +166,13 @@ public class OwnerContextListener implements ServletContextListener {
       @Override
       protected void replied(Composite reply) {
         String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + reply.toString());
+        logger.debug("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
         String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + request.toString());
+        logger.debug("msg/" + msgId + ": " + request.toString());
       }
 
       @Override

--- a/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerContextListener.java
+++ b/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerContextListener.java
@@ -73,9 +73,9 @@ public class ResellerContextListener implements ServletContextListener {
       final String ownerKeysPem = Files.readString(Paths.get(
               sc.getInitParameter(ResellerAppConstants.OWNER_PUB_KEY_PATH)));
       dbManager.defineKeySet(ds, ownerKeysPem, "owner", 1);
-      System.out.println("Registered public keys for customer 'owner'");
+      logger.info("Registered public keys for customer 'owner'");
     } catch (IOException e) {
-      System.out.println("No default public keys found for customer 'owner'");
+      logger.info("No default public keys found for customer 'owner'");
     }
   }
 

--- a/component-samples/rv/src/main/java/org/fidoalliance/fdo/sample/RvContextListener.java
+++ b/component-samples/rv/src/main/java/org/fidoalliance/fdo/sample/RvContextListener.java
@@ -90,13 +90,13 @@ public class RvContextListener implements ServletContextListener {
           @Override
           protected void replied(Composite reply) {
             String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-            logger.info("msg/" + msgId + ": " + reply.toString());
+            logger.debug("msg/" + msgId + ": " + reply.toString());
           }
 
           @Override
           protected void dispatching(Composite request) {
             String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
-            logger.info("msg/" + msgId + ": " + request.toString());
+            logger.debug("msg/" + msgId + ": " + request.toString());
           }
 
           @Override

--- a/component-samples/rv/src/main/java/org/fidoalliance/fdo/sample/RvContextListener.java
+++ b/component-samples/rv/src/main/java/org/fidoalliance/fdo/sample/RvContextListener.java
@@ -53,13 +53,14 @@ public class RvContextListener implements ServletContextListener {
     String epidTestMode = sc.getInitParameter(RvAppSettings.EPID_TEST_MODE);
     if (null != epidTestMode && Boolean.valueOf(epidTestMode)) {
       cs.setEpidTestMode();
-      sc.log("EPID Test mode enabled.");
+      logger.warn("*** WARNING ***");
+      logger.warn("EPID Test mode enabled. This should NOT be enabled in production deployment.");
     }
     String epidUrl = sc.getInitParameter(RvAppSettings.EPID_URL);
     if (null != epidUrl) {
       EpidUtils.setEpidOnlineUrl(epidUrl);
     } else {
-      sc.log("EPID URL not set. Default URL will be used: "
+      logger.info("EPID URL not set. Default URL will be used: "
               + EpidUtils.getEpidOnlineUrl().toString());
     }
 
@@ -88,21 +89,23 @@ public class RvContextListener implements ServletContextListener {
 
           @Override
           protected void replied(Composite reply) {
-            sc.log("replied with: " + reply.toString());
+            String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
+            logger.info("msg/" + msgId + ": " + reply.toString());
           }
 
           @Override
           protected void dispatching(Composite request) {
-            sc.log("dispatching: " + request.toString());
+            String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
+            logger.info("msg/" + msgId + ": " + request.toString());
           }
 
           @Override
           protected void failed(Exception e) {
             StringWriter writer = new StringWriter();
             try (PrintWriter pw = new PrintWriter(writer)) {
-              sc.log("Failed to write data: " + e.getMessage());
+              logger.warn("Failed to write data: " + e.getMessage());
             }
-            sc.log(writer.toString());
+            logger.warn(writer.toString());
           }
         };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);

--- a/http-api-samples/http-api-di-sample/src/main/java/org/fidoalliance/fdo/api/RvInfoServlet.java
+++ b/http-api-samples/http-api-di-sample/src/main/java/org/fidoalliance/fdo/api/RvInfoServlet.java
@@ -12,12 +12,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
+import org.fidoalliance.fdo.loggingutils.LoggerService;
 import org.fidoalliance.fdo.protocol.Composite;
 import org.fidoalliance.fdo.protocol.Const;
 import org.fidoalliance.fdo.protocol.RendezvousInfoDecoder;
 import org.fidoalliance.fdo.storage.DiDbManager;
 
 public class RvInfoServlet extends HttpServlet {
+
+  private static final LoggerService logger = new LoggerService(RvInfoServlet.class);
 
   @Override
   protected void doPost(HttpServletRequest req, HttpServletResponse resp)
@@ -45,12 +48,12 @@ public class RvInfoServlet extends HttpServlet {
         dbManager.addRvInfo(ds, rvInfo);
       } else {
         //If we are unable to resolve even one directive, then we return 400 BAD_REQUEST.
-        System.out.println("Received invalid RVInfo");
+        logger.error("Received invalid RVInfo");
         resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         return;
       }
     } catch (Exception e) {
-      System.out.println("Received invalid RVInfo");
+      logger.error("Received invalid RVInfo");
       resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       return;
     }

--- a/protocol-samples/http-server-di-sample/src/main/java/org/fidoalliance/fdo/sample/DiContextListener.java
+++ b/protocol-samples/http-server-di-sample/src/main/java/org/fidoalliance/fdo/sample/DiContextListener.java
@@ -266,13 +266,13 @@ public class DiContextListener implements ServletContextListener {
       @Override
       protected void replied(Composite reply) {
         String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + reply.toString());
+        logger.debug("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
         String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + request.toString());
+        logger.debug("msg/" + msgId + ": " + request.toString());
       }
 
       @Override

--- a/protocol-samples/http-server-di-sample/src/main/java/org/fidoalliance/fdo/sample/DiContextListener.java
+++ b/protocol-samples/http-server-di-sample/src/main/java/org/fidoalliance/fdo/sample/DiContextListener.java
@@ -265,21 +265,23 @@ public class DiContextListener implements ServletContextListener {
 
       @Override
       protected void replied(Composite reply) {
-        sc.log("replied with: " + reply.toString());
+        String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
-        sc.log("dispatching: " + request.toString());
+        String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + request.toString());
       }
 
       @Override
       protected void failed(Exception e) {
         StringWriter writer = new StringWriter();
         try (PrintWriter pw = new PrintWriter(writer)) {
-          sc.log("Failed to write data: " + e.getMessage());
+          logger.warn("Failed to write data: " + e.getMessage());
         }
-        sc.log(writer.toString());
+        logger.warn(writer.toString());
       }
     };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);

--- a/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ContextListener.java
+++ b/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ContextListener.java
@@ -80,21 +80,23 @@ public class To0To1ContextListener implements ServletContextListener {
 
       @Override
       protected void replied(Composite reply) {
-        sc.log("replied with: " + reply.toString());
+        String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
-        sc.log("dispatching: " + request.toString());
+        String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + request.toString());
       }
 
       @Override
       protected void failed(Exception e) {
         StringWriter writer = new StringWriter();
         try (PrintWriter pw = new PrintWriter(writer)) {
-          sc.log("Failed to write data: " + e.getMessage());
+          logger.warn("Failed to write data: " + e.getMessage());
         }
-        sc.log(writer.toString());
+        logger.warn(writer.toString());
       }
     };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);

--- a/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ContextListener.java
+++ b/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ContextListener.java
@@ -81,13 +81,13 @@ public class To0To1ContextListener implements ServletContextListener {
       @Override
       protected void replied(Composite reply) {
         String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + reply.toString());
+        logger.debug("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
         String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + request.toString());
+        logger.debug("msg/" + msgId + ": " + request.toString());
       }
 
       @Override

--- a/protocol-samples/http-server-to2-sample/src/main/java/org/fidoalliance/fdo/sample/To2ContextListener.java
+++ b/protocol-samples/http-server-to2-sample/src/main/java/org/fidoalliance/fdo/sample/To2ContextListener.java
@@ -197,6 +197,8 @@ public class To2ContextListener implements ServletContextListener {
     // Setting epid test mode enables epid signatures from debug and test
     // devices to pass validation. In production, this should never be used.
     cs.setEpidTestMode();
+    logger.warn("*** WARNING ***");
+    logger.warn("EPID Test mode enabled. This should NOT be enabled in production deployment.");
 
     sc.setAttribute("datasource", ds);
     sc.setAttribute("cryptoservice", cs);
@@ -259,21 +261,23 @@ public class To2ContextListener implements ServletContextListener {
 
       @Override
       protected void replied(Composite reply) {
-        sc.log("replied with: " + reply.toString());
+        String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
-        sc.log("dispatching: " + request.toString());
+        String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + request.toString());
       }
 
       @Override
       protected void failed(Exception e) {
         StringWriter writer = new StringWriter();
         try (PrintWriter pw = new PrintWriter(writer)) {
-          sc.log("Failed to write data: " + e.getMessage());
+          logger.warn("Failed to write data: " + e.getMessage());
         }
-        sc.log(writer.toString());
+        logger.warn(writer.toString());
       }
     };
     sc.setAttribute(Const.DISPATCHER_ATTRIBUTE, dispatcher);

--- a/protocol-samples/http-server-to2-sample/src/main/java/org/fidoalliance/fdo/sample/To2ContextListener.java
+++ b/protocol-samples/http-server-to2-sample/src/main/java/org/fidoalliance/fdo/sample/To2ContextListener.java
@@ -262,13 +262,13 @@ public class To2ContextListener implements ServletContextListener {
       @Override
       protected void replied(Composite reply) {
         String msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + reply.toString());
+        logger.debug("msg/" + msgId + ": " + reply.toString());
       }
 
       @Override
       protected void dispatching(Composite request) {
         String msgId = request.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + request.toString());
+        logger.debug("msg/" + msgId + ": " + request.toString());
       }
 
       @Override

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/RendezvousInfoDecoder.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/RendezvousInfoDecoder.java
@@ -12,10 +12,14 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.fidoalliance.fdo.loggingutils.LoggerService;
+
 /**
  * Decodes RendezvousInfo strings.
  */
 public class RendezvousInfoDecoder {
+
+  private static final LoggerService logger = new LoggerService(RendezvousInfoDecoder.class);
 
   private static boolean getBoolean(String value) {
     if (value.compareToIgnoreCase("true") == 0) {
@@ -219,7 +223,7 @@ public class RendezvousInfoDecoder {
           long rvVariable = (long) item.get(0);
           if (rvVariable < Const.RV_DEV_ONLY || rvVariable > Const.RV_EXTRV) {
             //Out of range rvVariable. Valid range is between 0-15.
-            System.out.println("Invalid RvVariable provided.");
+            logger.warn("Invalid RvVariable provided.");
             return false;
           } else if (rvVariable == Const.RV_DEV_ONLY || rvVariable == Const.RV_OWNER_ONLY
                   || rvVariable == Const.RV_BYPASS) {
@@ -234,14 +238,14 @@ public class RendezvousInfoDecoder {
             Integer devport = queryIntValue(directive, Const.RV_DEV_PORT);
             //Ensure that devport is in the valid range of (0,65535).
             if (devport < 0 || devport > 65535) {
-              System.out.println("Invalid devport.");
+              logger.warn("Invalid devport.");
               return false;
             }
           } else if (rvVariable == Const.RV_OWNER_PORT) {
             Integer ownerport = queryIntValue(directive, Const.RV_OWNER_PORT);
             //Ensure that ownerport is in the valid range of (0,65535).
             if (ownerport < 0 || ownerport > 65535) {
-              System.out.println("Invalid Ownerport.");
+              logger.warn("Invalid Ownerport.");
               return false;
             }
           } else if (rvVariable == Const.RV_SV_CERT_HASH) {
@@ -259,14 +263,14 @@ public class RendezvousInfoDecoder {
             Integer medium = queryIntValue(directive, Const.RV_DEV_PORT);
             //Ensure that medium is in the valid range of (0,21).
             if (medium < Const.RV_MED_ETH0 || medium > Const.RV_MED_WIFI_ALL) {
-              System.out.println("Invalid medium used.");
+              logger.warn("Invalid medium used.");
               return false;
             }
           } else if (rvVariable == Const.RV_PROTOCOL) {
             int value = queryIntValue(directive, Const.RV_PROTOCOL);
             //Ensure that protocol value is in the valid range of (0,6).
             if (value < Const.RV_PROT_REST || value > Const.RV_PROT_COAP_UDP) {
-              System.out.println("Invalid Protocol used.");
+              logger.warn("Invalid Protocol used.");
               return false;
             }
           } else if (rvVariable == Const.RV_DELAY_SEC) {
@@ -279,13 +283,13 @@ public class RendezvousInfoDecoder {
         }
       }
     } catch (InvalidIpAddressException e) {
-      System.out.println("Invalid IP address provided.");
+      logger.warn("Invalid IP address provided.");
       return false;
     } catch (MessageBodyException e) {
-      System.out.println("Invalid WiFi SSID/ WiFi PW provided.");
+      logger.warn("Invalid WiFi SSID/ WiFi PW provided.");
       return false;
     } catch (DispatchException e) {
-      System.out.println("Invalid user inpur provided.");
+      logger.warn("Invalid user input provided.");
     } catch (Exception e) {
       return false;
     }

--- a/util/http-dispatchers/http-client-dispatcher/src/main/java/org/fidoalliance/fdo/sample/WebClient.java
+++ b/util/http-dispatchers/http-client-dispatcher/src/main/java/org/fidoalliance/fdo/sample/WebClient.java
@@ -214,7 +214,6 @@ public class WebClient implements Runnable {
       HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
           .uri(URI.create(url));
 
-      byte[] body = message.getAsComposite(Const.SM_BODY).toBytes();
       reqBuilder.setHeader("Content-Type", Const.HTTP_APPLICATION_CBOR);
 
       Composite info = message.getAsComposite(Const.SM_PROTOCOL_INFO);
@@ -223,6 +222,10 @@ public class WebClient implements Runnable {
             Const.HTTP_BEARER + " " + info.getAsString(Const.PI_TOKEN));
       }
 
+      String msgId = message.getAsNumber(Const.SM_MSG_ID).toString();
+      logger.info("msg/" + msgId + ": " + message.toString());
+
+      byte[] body = message.getAsComposite(Const.SM_BODY).toBytes();
       reqBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(body));
 
       HttpResponse<byte[]> hr = httpClient
@@ -250,6 +253,9 @@ public class WebClient implements Runnable {
                 message.getAsNumber(Const.SM_PROTOCOL_VERSION))
             .set(Const.SM_PROTOCOL_INFO, authInfo)
             .set(Const.SM_BODY, Composite.fromObject(hr.body()));
+
+        msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
+        logger.info("msg/" + msgId + ": " + reply.toString());
 
         return new DispatchResult(reply, false);
       }

--- a/util/http-dispatchers/http-client-dispatcher/src/main/java/org/fidoalliance/fdo/sample/WebClient.java
+++ b/util/http-dispatchers/http-client-dispatcher/src/main/java/org/fidoalliance/fdo/sample/WebClient.java
@@ -223,7 +223,7 @@ public class WebClient implements Runnable {
       }
 
       String msgId = message.getAsNumber(Const.SM_MSG_ID).toString();
-      logger.info("msg/" + msgId + ": " + message.toString());
+      logger.debug("msg/" + msgId + ": " + message.toString());
 
       byte[] body = message.getAsComposite(Const.SM_BODY).toBytes();
       reqBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(body));
@@ -255,7 +255,7 @@ public class WebClient implements Runnable {
             .set(Const.SM_BODY, Composite.fromObject(hr.body()));
 
         msgId = reply.getAsNumber(Const.SM_MSG_ID).toString();
-        logger.info("msg/" + msgId + ": " + reply.toString());
+        logger.debug("msg/" + msgId + ": " + reply.toString());
 
         return new DispatchResult(reply, false);
       }

--- a/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerTestModule.java
+++ b/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerTestModule.java
@@ -6,6 +6,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.UUID;
 import javax.sql.DataSource;
+
+import org.fidoalliance.fdo.loggingutils.LoggerService;
 import org.fidoalliance.fdo.protocol.Composite;
 import org.fidoalliance.fdo.protocol.Const;
 import org.fidoalliance.fdo.serviceinfo.Module;
@@ -19,6 +21,8 @@ public class OwnerTestModule implements Module {
   private static final String TEST_MOD_ACTIVE = TEST_MOD_NAME + ":active";
   private final DataSource ds;
   private Composite state;
+
+  private static final LoggerService logger = new LoggerService(OwnerTestModule.class);
 
   /**
    * Constructs a OwnerTestModule.
@@ -91,7 +95,7 @@ public class OwnerTestModule implements Module {
   @Override
   public void setServiceInfo(Composite kvPair, boolean isMore) {
 
-    System.out.println(kvPair.getAsString(Const.FIRST_KEY));
+    logger.info(kvPair.getAsString(Const.FIRST_KEY));
     state.set(Const.THIRD_KEY, true);
 
   }


### PR DESCRIPTION
Include the message number while logging the protocol messages. This
would improve debugging capabilities.

In current implementation, the logging was enabled only for Services.
This is now extended for the Clients too (to0Client and Device).

In future, this would also help to prepare some analytics tool that can
parse the log message and create more useful information.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>
