### PR TITLE
Implements a REST endpoint in AIO for Serving Device Info

### DIFF
--- a/component-samples/aio/pom.xml
+++ b/component-samples/aio/pom.xml
@@ -26,6 +26,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>${json.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-dbcp2</artifactId>
       <version>${dbcp2.version}</version>

--- a/component-samples/aio/pom.xml
+++ b/component-samples/aio/pom.xml
@@ -26,9 +26,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>${json.version}</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioDbManager.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioDbManager.java
@@ -200,7 +200,6 @@ public class AioDbManager {
 
   /**
    * Get information about all devices in the database that completed DI.
-   *
    * This method is used in AioInfoServlet.
    */
   public String getDevicesInfo(DataSource ds) throws SQLException {
@@ -231,7 +230,6 @@ public class AioDbManager {
 
   /**
    * Get information about devices those were registered within a given period of time.
-   *
    * This method is used in AioInfoServlet.
    */
   public String  getDevicesInfoWithTime(DataSource ds, int seconds) throws SQLException {

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioDbManager.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioDbManager.java
@@ -3,6 +3,9 @@
 
 package org.fidoalliance.fdo.sample;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,8 +18,6 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import javax.sql.DataSource;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 /**
  * AIO Database Manager.
@@ -204,7 +205,8 @@ public class AioDbManager {
    */
   public String getDevicesInfo(DataSource ds) throws SQLException {
 
-    JSONArray list = new JSONArray();
+    ObjectMapper mapper = new ObjectMapper();
+    ArrayNode rootNode = mapper.createArrayNode();
     try (Connection conn = ds.getConnection();
          Statement stmt = conn.createStatement()) {
       StringBuilder builder = new StringBuilder();
@@ -213,19 +215,19 @@ public class AioDbManager {
 
       try (ResultSet rs = stmt.executeQuery(builder.toString())) {
         while (rs.next()) {
-          JSONObject obj = new JSONObject();
+          ObjectNode obj = mapper.createObjectNode();
           final String guid = rs.getString("GUID");
           final String serialNumber = rs.getString("SERIAL_NO");
           Timestamp timestamp = rs.getTimestamp("COMPLETED");
           obj.put("serial_no", serialNumber);
           obj.put("timestamp", timestamp.toString());
           obj.put("uuid", guid);
-          list.put(obj);
+          rootNode.add(obj);
         }
       }
     }
 
-    return list.toString();
+    return rootNode.toString();
   }
 
   /**
@@ -234,7 +236,8 @@ public class AioDbManager {
    */
   public String  getDevicesInfoWithTime(DataSource ds, int seconds) throws SQLException {
 
-    JSONArray list = new JSONArray();
+    ObjectMapper mapper = new ObjectMapper();
+    ArrayNode rootNode = mapper.createArrayNode();
     try (Connection conn = ds.getConnection();
          Statement stmt = conn.createStatement()) {
       StringBuilder builder = new StringBuilder();
@@ -251,16 +254,16 @@ public class AioDbManager {
           long diff = cur.getTime() - timestamp.getTime();
           long diffSeconds = diff / 1000;
           if (diffSeconds < seconds) {
-            JSONObject obj = new JSONObject();
+            ObjectNode obj = mapper.createObjectNode();
             obj.put("serial_no", serialNumber);
             obj.put("timestamp", timestamp.toString());
             obj.put("uuid", guid);
-            list.put(obj);
+            rootNode.add(obj);
           }
         }
       }
     }
-    return list.toString();
+    return rootNode.toString();
   }
 
 }

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioInfoServlet.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioInfoServlet.java
@@ -3,9 +3,12 @@
 
 package org.fidoalliance.fdo.sample;
 
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.fidoalliance.fdo.loggingutils.LoggerService;
-
+import java.io.PrintWriter;
+import java.net.URI;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.AsyncContext;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServlet;
@@ -13,12 +16,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import javax.xml.crypto.Data;
-import java.io.*;
-import java.net.URI;
-import java.nio.file.Path;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.fidoalliance.fdo.loggingutils.LoggerService;
 
 /**
  * AioInfoServlet serves Device information that completed DI.

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioInfoServlet.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioInfoServlet.java
@@ -1,0 +1,106 @@
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package org.fidoalliance.fdo.sample;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.fidoalliance.fdo.loggingutils.LoggerService;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import javax.xml.crypto.Data;
+import java.io.*;
+import java.net.URI;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AioInfoServlet serves Device information that completed DI.
+ */
+public class AioInfoServlet extends HttpServlet {
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    final AsyncContext asyncCtx = req.startAsync();
+    asyncCtx.setTimeout(0);
+    new Thread(() -> getAsync(asyncCtx)).start();
+  }
+
+  protected String getPathName(String path) {
+    String result = "";
+    int pos = path.lastIndexOf('/');
+    if (pos >= 0) {
+      result = path.substring(pos + 1);
+    }
+    return result;
+  }
+
+  protected String getPath(String path) {
+    String result = "";
+    int pos = path.lastIndexOf('/');
+    if (pos >= 0) {
+      result = path.substring(0, pos);
+    }
+    return result;
+  }
+
+  protected List<String> getPathElements(String uriString) {
+
+    List<String> list = new ArrayList<>();
+    URI uri = URI.create(uriString);
+    String parentPath = uri.getPath();
+
+    String pathName = getPathName(parentPath);
+    while (pathName.length() > 0) {
+      list.add(0, pathName);
+      parentPath = getPath(parentPath);
+      pathName = getPathName((parentPath));
+    }
+    return list;
+  }
+
+  private void getAsync(AsyncContext asyncCtx) {
+    LoggerService logger = new LoggerService(AioInfoServlet.class);
+    AioDbManager db = new AioDbManager();
+
+    HttpServletRequest req = (HttpServletRequest) asyncCtx.getRequest();
+    HttpServletResponse res = (HttpServletResponse) asyncCtx.getResponse();
+    ServletContext sc = req.getServletContext();
+    BasicDataSource ds = (BasicDataSource) sc.getAttribute("datasource");
+
+    List<String> list = getPathElements(req.getRequestURI());
+    logger.info(list.toString());
+    if (list.size() > 3) {
+      try {
+        int pollTime = Integer.parseInt(list.get(3));
+        if (pollTime < 0) {
+          pollTime = 20;
+        }
+        res.setContentType("application/json");
+        res.setCharacterEncoding("utf-8");
+        PrintWriter out = res.getWriter();
+        out.print(db.getDevicesInfoWithTime(ds, pollTime));
+      } catch (NumberFormatException e) {
+        logger.error("Invalid poll time. Couldn't fetch device information.");
+      } catch (Exception e) {
+        logger.error("Unable to retrieve Device Information.");
+      }
+    } else {
+      try {
+        res.setContentType("application/json");
+        res.setCharacterEncoding("utf-8");
+        PrintWriter out = res.getWriter();
+        out.print(db.getDevicesInfo(ds));
+      } catch (Exception e) {
+        logger.error("Unable to retrieve Device Information.");
+      }
+    }
+    asyncCtx.complete();
+  }
+}

--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioServerApp.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioServerApp.java
@@ -179,6 +179,10 @@ public class AioServerApp {
     wrapper.addMapping("/api/v1/vouchers/*");
     wrapper.setAsyncSupported(true);
 
+    wrapper = tomcat.addServlet(ctx, "AioInfoServlet", new AioInfoServlet());
+    wrapper.addMapping("/api/v1/deviceinfo/*");
+    wrapper.setAsyncSupported(true);
+
     wrapper = tomcat.addServlet(ctx, "AssignCustomerApi", new AssignCustomerServlet());
     wrapper.addMapping("/api/v1/assign/*");
     wrapper.setAsyncSupported(true);

--- a/component-samples/demo/aio/README.md
+++ b/component-samples/demo/aio/README.md
@@ -219,6 +219,7 @@ Refer to the section [Docker Commands](../README.md/#docker-commands) to start t
 | ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|
 | PUT /api/v1/uploads/<file> | PUT a file that can later be retrieved via /downloads api |  | | | |
 | GET /downloads/<file> | Gets for onboarding   | | | |
+| GET /api/v1/deviceinfo/{seconds} | Serves the serial no. and GUID of the devices that completed DI in last `n` seconds | |||
 
 
 ***NOTE***: These REST APIs use Digest authentication. `owner_api_user` and `owner_api_password` properties specify the credentials to be used while making the REST calls.

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <h2.version>1.4.200</h2.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
+    <json.version>20210307</json.version>
     <junit-jupiter.version>5.8.0-M1</junit-jupiter.version>
     <log4j.version>2.14.1</log4j.version>
     <slf4j.version>1.7.30</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <h2.version>1.4.200</h2.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
-    <json.version>20210307</json.version>
+    <jackson.version>2.12.4</jackson.version>
     <junit-jupiter.version>5.8.0-M1</junit-jupiter.version>
     <log4j.version>2.14.1</log4j.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
  Implements a REST end-point to for serving additional device information from
  AIO. The REST end-point extracts following information from the database.
  - SerialNumber
  - Timestamp for DI
  - Device GUID
  and serves this information through /api/v1/deviceinfo/* REST
  endpoints.

Signed-off-by: Davis Benny <davis.benny@intel.com>