### PR TITLE
Fix some minor issues with serviceinfo

### DIFF
--- a/util/serviceinfo/src/main/java/org/fidoalliance/fdo/serviceinfo/ModuleManager.java
+++ b/util/serviceinfo/src/main/java/org/fidoalliance/fdo/serviceinfo/ModuleManager.java
@@ -229,6 +229,9 @@ public class ModuleManager implements Module {
 
     while (hasMore()) {
       Composite kvPair = nextMessage();
+      if (kvPair.size() == 0) {
+        break;
+      }
       list.add(kvPair);
 
       Composite calcSvi = ServiceInfoEncoder.encodeOwnerServiceInfo(
@@ -237,9 +240,6 @@ public class ModuleManager implements Module {
       if (len > mtu) {
         list.remove(kvPair);
         state.set(Const.FOURTH_KEY, kvPair);//set extra
-        break;
-      }
-      if (kvPair.size() == 0) {
         break;
       }
     }

--- a/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerSysModule.java
+++ b/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerSysModule.java
@@ -92,7 +92,8 @@ public class OwnerSysModule implements Module {
 
   @Override
   public boolean isMore() {
-    return state.getAsBoolean(Const.FIFTH_KEY);
+    return state.getAsBoolean(Const.FIFTH_KEY)
+        || state.getAsBoolean(Const.SEVENTH_KEY);
   }
 
   @Override
@@ -181,7 +182,10 @@ public class OwnerSysModule implements Module {
           if (!getBooleanContent(resId)) {
             state.set(Const.FIFTH_KEY, false); //ismore
             state.set(Const.SIXTH_KEY, true);//isdone - device not active
+            // remove everything and add the same resource back,
+            // since this specific resource still needs to be sent back to the device
             resList.clear();
+            resList.set(resIndex, resource);
           }
           state.set(Const.SEVENTH_KEY, true); //has message to send
           break;


### PR DESCRIPTION
- Fix an issue where the 'fdo_sys:active=false' was not sent to the
device.
- Fix an issue where empty ServiceInfo was being sent as [[[]]], instead
of [].
- Fix an issue where OwnerSysModule was always returning 'false' at
isMore(), by aligning hasMore()'s return with isMore().

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>