### PR TITLE
Disable credential reuse in the owner

### DIFF
--- a/http-api-samples/http-api-owner-sample/src/main/java/org/fidoalliance/fdo/api/OwnerSetupInfoServlet.java
+++ b/http-api-samples/http-api-owner-sample/src/main/java/org/fidoalliance/fdo/api/OwnerSetupInfoServlet.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import org.fidoalliance.fdo.protocol.Const;
+import org.fidoalliance.fdo.protocol.Debug;
 import org.fidoalliance.fdo.storage.OwnerDbManager;
 
 public class OwnerSetupInfoServlet extends HttpServlet {
@@ -68,9 +69,14 @@ public class OwnerSetupInfoServlet extends HttpServlet {
           if (si.length == 2) {
             switch (si[0]) {
               case SETUPINFO_GUID:
-                replacementGuid = UUID.fromString(si[1]);
-                getServletContext().log("Updating Replacement GUID for " + currentGuid.toString());
-                ownerDbManager.updateDeviceReplacementGuid(ds, currentGuid, replacementGuid);
+                if (Debug.IS_REUSE_DISABLED) {
+                  getServletContext().log("Reuse not enabled.  GUID cannot be set manually.");
+                } else {
+                  replacementGuid = UUID.fromString(si[1]);
+                  getServletContext().log(
+                      "Updating Replacement GUID for " + currentGuid.toString());
+                  ownerDbManager.updateDeviceReplacementGuid(ds, currentGuid, replacementGuid);
+                }
                 break;
               case SETUPINFO_RVINFO:
                 replacementRvInfo = si[1];

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/Debug.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/Debug.java
@@ -1,0 +1,11 @@
+package org.fidoalliance.fdo.protocol;
+
+/**
+ * Flags which control debug modes.
+ */
+public abstract class Debug {
+
+  // Set this flag to false to enable credential reuse.
+  public static final Boolean IS_REUSE_DISABLED = true;
+
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ServerStorage.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/To2ServerStorage.java
@@ -46,6 +46,10 @@ public interface To2ServerStorage extends StorageEvents {
 
   UUID getReplacementGuid();
 
+  default UUID generateReplacementGuid(UUID oldUuid) {
+    return UUID.randomUUID();
+  }
+
   Composite getReplacementOwnerKey();
 
   void discardReplacementOwnerKey();

--- a/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerDbStorage.java
+++ b/util/storage-samples/storage-owner-sample/src/main/java/org/fidoalliance/fdo/storage/OwnerDbStorage.java
@@ -235,6 +235,26 @@ public class OwnerDbStorage implements To2ServerStorage {
   }
 
   @Override
+  public UUID generateReplacementGuid(UUID oldUuid) {
+
+    UUID newUuid = UUID.randomUUID();
+    String sql = "UPDATE TO2_DEVICES"
+        + " SET REPLACEMENT_GUID = ?"
+        + " WHERE GUID = ?;";
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+      pstmt.setString(1, newUuid.toString());
+      pstmt.setString(2, oldUuid.toString());
+      pstmt.executeUpdate();
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+
+    return newUuid;
+  }
+
+  @Override
   public UUID getReplacementGuid() {
 
     String sql = "SELECT REPLACEMENT_GUID FROM TO2_DEVICES WHERE GUID = ?;";


### PR DESCRIPTION
Add a flag, Debug.IS_REUSE_DISABLED, which controls reuse
in the owner.  By default, reuse is disabled and replacement
GUIDs are auto-generated.

Signed-off-by: Greg Bean <greg.bean@intel.com>