### PR TITLE
Revert TO0 scheduler interval to 300s

### DIFF
--- a/component-samples/demo/owner/owner.env
+++ b/component-samples/demo/owner/owner.env
@@ -8,7 +8,7 @@ owner_database_port=8051
 catalina_home=./target/tomcat
 owner_keystore=./owner_keystore.p12
 owner_to0_scheduling_enabled=true
-owner_to0_scheduling_interval=10
+owner_to0_scheduling_interval=300
 owner_to0_rv_blob=http://localhost:8042?ipaddress=127.0.0.1
 owner_svi_values=./serviceinfo/sample-values
 owner_svi_string=./serviceinfo/sample-svi.csv


### PR DESCRIPTION
The TO0 scheduler time was changed from 300s to 10s by mistake,
reverting back to original value.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>