### PR TITLE
Auto-generate API password

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -22,7 +22,7 @@ node('ubuntu18.04-OnDemand'){
     {
 
       // Checking out the smoke test code
-      checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'test-fidoiot']], userRemoteConfigs: [[credentialsId: 'sdo-automationgithubtoken', url: 'https://github.com/secure-device-onboard/test-fidoiot']]])
+      checkout([$class: 'GitSCM', branches: [[name: '*/trb-api-pass']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'test-fidoiot']], userRemoteConfigs: [[credentialsId: 'sdo-automationgithubtoken', url: 'https://github.com/trbehera/test-fidoiot']]])
 
       // Creating the required directories
       sh '''

--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -22,7 +22,7 @@ node('ubuntu18.04-OnDemand'){
     {
 
       // Checking out the smoke test code
-      checkout([$class: 'GitSCM', branches: [[name: '*/trb-api-pass']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'test-fidoiot']], userRemoteConfigs: [[credentialsId: 'sdo-automationgithubtoken', url: 'https://github.com/trbehera/test-fidoiot']]])
+      checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'test-fidoiot']], userRemoteConfigs: [[credentialsId: 'sdo-automationgithubtoken', url: 'https://github.com/secure-device-onboard/test-fidoiot']]])
 
       // Creating the required directories
       sh '''

--- a/component-samples/demo/aio/aio.env
+++ b/component-samples/demo/aio/aio.env
@@ -34,7 +34,6 @@ ondie_zip_artifact=
 ondie_check_revocations=true
 
 aio_api_user=apiUser
-aio_api_password=OwnerApiPass123
 
 ## PRI Owner Keystore & Truststore Credentials
 ## NOTE:   Appropriate security measures with respect to key-store management and configuration

--- a/component-samples/demo/manufacturer/manufacturer.env
+++ b/component-samples/demo/manufacturer/manufacturer.env
@@ -5,7 +5,6 @@ manufacturer_database_password=
 manufacturer_database_port=8049
 catalina_home=./target/tomcat
 manufacturer_api_user=apiUser
-manufacturer_api_password=MfgApiPass123
 
 ## PRI Manufacturer Keystore File & Credentials
 ## NOTE:   Appropriate security measures with respect to key-store management and configuration

--- a/component-samples/demo/owner/owner.env
+++ b/component-samples/demo/owner/owner.env
@@ -13,7 +13,6 @@ owner_to0_rv_blob=http://localhost:8042?ipaddress=127.0.0.1
 owner_svi_values=./serviceinfo/sample-values
 owner_svi_string=./serviceinfo/sample-svi.csv
 owner_api_user=apiUser
-owner_api_password=OwnerApiPass123
 
 ## PRI Owner Keystore & Truststore Credentials
 ## NOTE:   Appropriate security measures with respect to key-store management and configuration

--- a/component-samples/demo/reseller/reseller.env
+++ b/component-samples/demo/reseller/reseller.env
@@ -7,8 +7,7 @@ reseller_home=./target/tomcat
 reseller_keystore=reseller_keystore.p12
 reseller_keystore_type=PKCS12
 reseller_database_driver=org.h2.Driver
-reseller_api_user=admin
-reseller_api_password=test
+reseller_api_user=apiUser
 
 # Reseller HTTPS configuration.
 reseller_protocol_scheme=http

--- a/component-samples/demo/scripts/keys_gen.sh
+++ b/component-samples/demo/scripts/keys_gen.sh
@@ -306,6 +306,17 @@ generate_component_keys()
   printf " successful\n"
 }
 
+generate_api_pass()
+{
+  api_pass=`openssl rand --base64 12 | tr -dc 0-9A-Za-z`
+
+  # Update API password
+  for comp in "aio" "manufacturer" "owner" "reseller"; do
+    pass_update_env_files $CREDS_PATH/$comp "${comp}_api_password=${api_pass}"
+  done
+
+}
+
 # Updating all component key hashes to the RV config.properties
 prepare_rv_config()
 {
@@ -509,6 +520,7 @@ start_generation()
             generate_component_keys $i
           fi
         done
+        generate_api_pass
         prepare_rv_config;
         generate_tls_keystore
         device_pem_files

--- a/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerServerApp.java
+++ b/component-samples/reseller/src/main/java/org/fidoalliance/fdo/sample/ResellerServerApp.java
@@ -166,7 +166,7 @@ public class ResellerServerApp {
     constraint.addCollection(collection);
     ctx.addConstraint(constraint);
 
-    tomcat.addRole("admin", AUTH_ROLE);
+    tomcat.addRole(ResellerConfigLoader.loadConfig(ResellerAppConstants.API_USER), AUTH_ROLE);
     tomcat.addUser(ResellerConfigLoader.loadConfig(ResellerAppConstants.API_USER),
         ResellerConfigLoader.loadConfig(ResellerAppConstants.API_PWD));
 


### PR DESCRIPTION
Updated the keys_gen.sh script to generate the API password during
runtime. The component env files are updated to remove the password for
API access.

While at it, reseller component is updated to take the username from
environment variable.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>