### PR TITLE
Enabling TLS by default in manufacturer

### DIFF
--- a/component-samples/demo/manufacturer/manufacturer.env
+++ b/component-samples/demo/manufacturer/manufacturer.env
@@ -20,7 +20,7 @@ manufacturer_api_user=apiUser
 ##         management should be considered while performing production deployment of PRI-Manufacturer.
 
 # Manufacturer HTTPS configuration
-manufacturer_protocol_scheme=http
+manufacturer_protocol_scheme=https
 manufacturer_https_port=8038
 manufacturer_keystore=manufacturer_keystore.p12
 manufacturer_ssl_keystore=certs/ssl.p12


### PR DESCRIPTION
  Enabling TLS by default in manufacturer.

Signed-off-by: Davis Benny <davis.benny@intel.com>