### PR TITLE
Update OnDie Cache configurations

### DIFF
--- a/component-samples/demo/README.md
+++ b/component-samples/demo/README.md
@@ -97,7 +97,7 @@ If no proxy needs to be specified, do not add these properties to your _JAVA_OPT
 
 OnDie is a type of device that makes use of the MAROE prefix. If you need to support such devices then you will need to configure the FDO PRI demo components by adding/updating the following properties. The values can be specified via Java -Doptions, entries in application.properties or entries the .env files.
 
-OnDie requires several certificates and CRLs. These artifacts can be downloaded from the cloud with the script provided in the component-samples/scripts directory (onDieCache.py). They can also be downloaded directly from java if the ondie_autoupdate property is set to true. These certificates and CRLs need to be copied to the Docker container in case OnDie is supported.
+OnDie requires several certificates and CRLs. These artifacts can be downloaded from the cloud with the [onDieCache.py script](scripts/onDieCache.py). They can also be downloaded directly during runtime if the `ondie_autoupdate` property is set to true. These certificates and CRLs need to be copied to the Docker container in case OnDie is supported.
 
 ***NOTE***: If you are using pre-production devices or an emulated device then certain debug certificates are required. In such cases, it is recommended that the ondie_cache value be set to the <fdo-pri-src>/protocol-samples/ondiecache directory which contains these debug certificates.
 
@@ -110,7 +110,7 @@ Note that this requires internet access by the component.
 Ensure `ondie_cache` directory is present before executing the script.
 
 ```
-python3 component-samples/scripts/onDieCache.py --cachedir <path-to-ondie_cache-directory>
+python3 scripts/onDieCache.py --cachedir <path-to-ondie_cache-directory>
 ```
 *Requires internet access for the component.
 
@@ -118,9 +118,6 @@ Finally, the `ondie_cache` directory needs to be copied into the docker containe
 ```
 COPY ./ondie_cache ./ondie_cache/
 ```
-*For Owner component, add `--chown=owner` along with the `COPY` command. Eg: `COPY --chown=owner ./ondie_cache ./ondie_cache/`
-
-`ondie_zip_artifact`: (optional, default = https://tsci.intel.com/content/csme.zip). Specifies the URL of the zip file that contains the OnDie certificates and CRLs.
 
 `ondie_check_revocations`: (optional, default = true for Manufacturer and Owner, false for RV) if "true" then revocations are checked by the component, no revocation checking is done if "false".
 
@@ -128,7 +125,7 @@ To enable OnDie support in FDO PRI Manufacturer and FDO PRI Owner, uncomment the
 
 ```
 ondie_cache=file:///home/fdo/ondie_cache/
-ondie_autoupdate=true
+ondie_autoupdate=false
 ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
 ondie_check_revocations=false
 ```

--- a/component-samples/demo/aio/aio.env
+++ b/component-samples/demo/aio/aio.env
@@ -29,8 +29,8 @@ manufacturer_keystore_type=PKCS12
 # ondie_cache directory must be absolute
 ondie_cache=file:///home/fdo/ondie_cache/
 ondie_autoupdate=false
-ondie_zip_artifact=
-ondie_check_revocations=true
+ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
+ondie_check_revocations=false
 
 aio_api_user=apiUser
 aio_auto_inject_blob=true

--- a/component-samples/demo/manufacturer/Dockerfile
+++ b/component-samples/demo/manufacturer/Dockerfile
@@ -10,12 +10,10 @@ RUN useradd -ms /bin/bash fdo
 RUN mkdir -p /home/fdo/lib
 WORKDIR /home/fdo/
 
-# Uncomment the following line to enable onDie support for manufacturer
-# COPY ./ondie_cache ./ondie_cache/
-
 # Setup manufacturer dependencies
 COPY ./lib ./lib/
 COPY ./certs ./certs/
+COPY ./ondie_cache ./ondie_cache/
 COPY log4j2.xml .
 COPY manufacturer.jar .
 COPY manufacturer_keystore.p12 owner_pub_keys.pem* reseller_pub_keys.pem* ./

--- a/component-samples/demo/manufacturer/manufacturer.env
+++ b/component-samples/demo/manufacturer/manufacturer.env
@@ -7,13 +7,10 @@ catalina_home=./target/tomcat
 manufacturer_api_user=apiUser
 
 ## PRI Manufacturer onDie Congfigurations
-## Uncomment the following lines to enable onDie support
-
-#ondie_cache=file:///home/fdo/ondie_cache/
-#ondie_autoupdate=true
-#ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
-#ondie_check_revocations=false
-
+ondie_cache=file:///home/fdo/ondie_cache/
+ondie_autoupdate=false
+ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
+ondie_check_revocations=false
 
 ## PRI Manufacturer Keystore File & Credentials
 ## NOTE:   Appropriate security measures with respect to key-store management and configuration

--- a/component-samples/demo/owner/Dockerfile
+++ b/component-samples/demo/owner/Dockerfile
@@ -10,12 +10,10 @@ RUN useradd -ms /bin/bash fdo
 WORKDIR /home/fdo/
 RUN mkdir -p /home/fdo/lib /home/fdo/serviceinfo
 
-# Uncomment the following line to enable onDie support for Owner
-# COPY ./ondie_cache ./ondie_cache/
-
 # Setup owner dependencies
 COPY ./lib ./lib/
 COPY ./certs ./certs/
+COPY ./ondie_cache ./ondie_cache/
 COPY log4j2.xml .
 COPY owner.jar .
 COPY owner_keystore.p12 owner_pub_keys.pem* owner2_pub_keys.pem* ./

--- a/component-samples/demo/owner/owner.env
+++ b/component-samples/demo/owner/owner.env
@@ -15,12 +15,10 @@ owner_svi_string=./serviceinfo/sample-svi.csv
 owner_api_user=apiUser
 
 ## PRI Owner onDie Congfigurations
-## Uncomment the following lines to enable onDie support
-
-#ondie_cache=file:///home/fdo/ondie_cache/
-#ondie_autoupdate=true
-#ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
-#ondie_check_revocations=false
+ondie_cache=file:///home/fdo/ondie_cache/
+ondie_autoupdate=false
+ondie_zip_artifact=https://tsci.intel.com/content/csme.zip
+ondie_check_revocations=false
 
 ## PRI Owner Keystore & Truststore Credentials
 ## NOTE:   Appropriate security measures with respect to key-store management and configuration

--- a/component-samples/demo/scripts/onDieCache.py
+++ b/component-samples/demo/scripts/onDieCache.py
@@ -38,7 +38,7 @@ def artifact_copy(source_pathname, destdir):
 
 parser = argparse.ArgumentParser(description='Update local OnDieCache.')
 parser = argparse.ArgumentParser(prog='ondieCache', usage='%(prog)s --cachedir CACHEDIR -f')
-parser.add_argument('-c', '--cachedir', required=True, help='local directory to store cache artifacts')
+parser.add_argument('--cachedir', required=True, help='local directory to store cache artifacts, the directory must exist.')
 parser.add_argument('-f', required=False, action='store_true', help='force update when previous update not yet processed')
 
 args = parser.parse_args()


### PR DESCRIPTION
Update the example configurations for on-prem setup.

In order to enable OnDie support, the script 'onDieCache.py' needs to be
run before starting the docker container to populate the ondie_cache
directory.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>