### PR TITLE
Disable PGP verification in docker build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -15,17 +15,24 @@ export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 REMOTE_URL=https://github.com/secure-device-onboard/pri-fidoiot.git
 REMOTE_BRANCH=master
 
+# The PGP signature verification requires additional proxy configuration in
+# ~/.m2/settings.xml. For simplicity and easier out of box experience, the PGP
+# signature verification is disabled here. In case this is used to create
+# production build, it is recommended to update ~/.m2/settings.xml to include
+# proxy configurations.
+MVN_CONFIG="-Dpgpverify.skip=true"
+
 if [ "$use_remote" = "1" ]; then
   echo "Building $REMOTE_URL : $REMOTE_BRANCH"
   git clone -b $REMOTE_BRANCH $REMOTE_URL /tmp/pri-fidoiot
 
   # Build source code
   cd /tmp/pri-fidoiot
-  mvn clean install
+  mvn clean install ${MVN_CONFIG}
 
   # Replace the demo folder in local copy
   cp -arufv /tmp/pri-fidoiot/component-samples/demo/* /home/fdouser/pri-fidoiot/component-samples/demo/
 else
   echo "Building local copy"
-  mvn clean install
+  mvn clean install ${MVN_CONFIG}
 fi


### PR DESCRIPTION
The PGP signature verification requires additional proxy configuration in
~/.m2/settings.xml. For simplicity and easier out of box experience, the PGP
signature verification is disabled here. In case this is used to create
production build, it is recommended to update ~/.m2/settings.xml to include
proxy configurations.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>