### PR TITLE
Remove disclaimer from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-***NOTE***: This is a preliminary implementation of the [FIDO Device Onboard Spec](https://fidoalliance.org/specs/FDO/fido-device-onboard-v1.0-ps-20210323/) published by the FIDO Alliance. The implementation is experimental and incomplete, and is not ready for use in any production capacity. Some cryptographic algorithms and encoding formats have not been implemented, and any aspect of this implementation is subject to change.
-
 # FIDO Device Onboard (FDO) Protocol Reference Implementation (PRI) Quick Start
+
+This is a reference implementation of the
+[FIDO Device Onboard Spec](https://fidoalliance.org/specs/FDO/fido-device-onboard-v1.0-ps-20210323/)
+published by the FIDO Alliance. It provides production-ready implementation for the protocol defined
+by the specification. It also provides example implementation for different components to
+demonstrate end-to-end execution of the protocol. Appropriate security measures should be taken while
+deploying the example implementation for these components.
 
 ## System Requirements:
 


### PR DESCRIPTION
The implementation version v1.0.0 complies to FIDO Device Onboard
Specification, but a note for earlier release was left out in the README
file claiming it to be a preliminary release.

Fixes issue #351 

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>