### PR TITLE
Fixing the exception raised while extending the device with invalid keyformat

### DIFF
--- a/http-api-samples/http-api-di-sample/src/main/java/org/fidoalliance/fdo/api/DiApiServlet.java
+++ b/http-api-samples/http-api-di-sample/src/main/java/org/fidoalliance/fdo/api/DiApiServlet.java
@@ -77,8 +77,14 @@ public class DiApiServlet extends HttpServlet {
     }
 
     Composite voucher = result.getAsComposite(Const.FIRST_KEY);
-    List<PublicKey> certs =
-        PemLoader.loadPublicKeys(result.getAsString(Const.SECOND_KEY));
+    List<PublicKey> certs;
+    try {
+      certs = PemLoader.loadPublicKeys(result.getAsString(Const.SECOND_KEY));
+    } catch (Exception e) {
+      logger.error("Invalid customer key in DB.");
+      resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      return;
+    }
 
     Composite ovh = voucher.getAsComposite(Const.OV_HEADER);
     Composite mfgPub = ovh.getAsComposite(Const.OVH_PUB_KEY);


### PR DESCRIPTION
   Fixing the exception raised while extending the device with invalid
   key formats. Now manufacturer returns a 500 error code, if invalid
   key is present in the database.

Signed-off-by: Davis Benny <davis.benny@intel.com>