### PR TITLE
Fix to enable HTTPS port by default on reseller

### DIFF
--- a/component-samples/demo/reseller/reseller.env
+++ b/component-samples/demo/reseller/reseller.env
@@ -10,7 +10,7 @@ reseller_database_driver=org.h2.Driver
 reseller_api_user=apiUser
 
 # Reseller HTTPS configuration.
-reseller_protocol_scheme=http
+reseller_protocol_scheme=https
 reseller_https_port=8072
 reseller_ssl_keystore=certs/ssl.p12
 


### PR DESCRIPTION
  Fix to enable HTTPS port by default on reseller.

Signed-off-by: Davis Benny <davis.benny@intel.com>