### PR TITLE
Fixing predictable authorization token issue in manufacturer

### DIFF
--- a/util/storage-samples/storage-di-sample/src/main/java/org/fidoalliance/fdo/storage/DiDbManager.java
+++ b/util/storage-samples/storage-di-sample/src/main/java/org/fidoalliance/fdo/storage/DiDbManager.java
@@ -28,6 +28,16 @@ public class DiDbManager {
         Statement stmt = conn.createStatement()) {
 
       String sql = "CREATE TABLE IF NOT EXISTS "
+              + "DI_SESSIONS ("
+              + "SESSION_ID CHAR(36) PRIMARY KEY, "
+              + "GUID CHAR(36), "
+              + "CREATED TIMESTAMP,"
+              + "UPDATED TIMESTAMP"
+              + ");";
+
+      stmt.executeUpdate(sql);
+
+      sql = "CREATE TABLE IF NOT EXISTS "
           + "MT_SETTINGS ("
           + "ID INT NOT NULL, "
           + "CERTIFICATE_VALIDITY_DAYS INT, "


### PR DESCRIPTION
   Fixing predictable authorized token issue in manufacturer.
   Previously, the token was same as guid. Now we are
   generating a random token for every guid.

   This commit also introduces a database table for storing
   DI session information. The table includes 4 attributes
   sessionID, GUID, created & updated.

Signed-off-by: Davis Benny <davis.benny@intel.com>