### PR TITLE
Fixing AioInfoServlet to return proper error codes on invalid inputs

### DIFF
--- a/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioInfoServlet.java
+++ b/component-samples/aio/src/main/java/org/fidoalliance/fdo/sample/AioInfoServlet.java
@@ -79,6 +79,7 @@ public class AioInfoServlet extends HttpServlet {
       try {
         int pollTime = Integer.parseInt(list.get(3));
         if (pollTime < 0) {
+          logger.warn("Received negative poll time. Defaulting to 20 seconds.");
           pollTime = 20;
         }
         res.setContentType("application/json");
@@ -87,8 +88,12 @@ public class AioInfoServlet extends HttpServlet {
         out.print(db.getDevicesInfoWithTime(ds, pollTime));
       } catch (NumberFormatException e) {
         logger.error("Invalid poll time. Couldn't fetch device information.");
+        res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
       } catch (Exception e) {
         logger.error("Unable to retrieve Device Information.");
+        res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
       }
     } else {
       try {
@@ -98,6 +103,8 @@ public class AioInfoServlet extends HttpServlet {
         out.print(db.getDevicesInfo(ds));
       } catch (Exception e) {
         logger.error("Unable to retrieve Device Information.");
+        res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        return;
       }
     }
     asyncCtx.complete();

--- a/component-samples/demo/scripts/get-cbor-bytes.sh
+++ b/component-samples/demo/scripts/get-cbor-bytes.sh
@@ -18,6 +18,6 @@
 default_diagnostic="[[[5, \"localhost\"], [3, 8040], [12, 1], [2, h'7F000001'], [4, 8041]]]"
 diagnostic=${1:-$default_diagnostic}
 parameterized_diagnostic=`echo $diagnostic | sed 's/ /%20/g' | sed 's/"/%22/g' | sed "s/'/%27/g"`
-result=`curl http://cbor.me/?diag=${parameterized_diagnostic} --globoff `
+result=`curl https://cbor.me/?diag=${parameterized_diagnostic} --globoff `
 echo -n "Byte Value : "
 echo $result | grep -o "bytes=.*>Bytes" | sed 's/bytes=//g' | sed 's/>Bytes//g' | sed 's/[^A-F0-9]//g'

--- a/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ContextListener.java
+++ b/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ContextListener.java
@@ -21,6 +21,7 @@ import org.fidoalliance.fdo.protocol.To0ServerService;
 import org.fidoalliance.fdo.protocol.To0ServerStorage;
 import org.fidoalliance.fdo.protocol.To1ServerService;
 import org.fidoalliance.fdo.protocol.To1ServerStorage;
+import org.fidoalliance.fdo.protocol.epid.EpidUtils;
 import org.fidoalliance.fdo.protocol.ondie.OnDieCache;
 import org.fidoalliance.fdo.protocol.ondie.OnDieService;
 import org.fidoalliance.fdo.storage.RvsDbManager;
@@ -59,6 +60,10 @@ public class To0To1ContextListener implements ServletContextListener {
         logger.warn("EPID Test mode enabled. This should NOT be enabled in production deployment.");
       } else {
         logger.info("*** EPID test mode disabled. ***");
+      }
+      String epidUrl = sc.getInitParameter("epid_online_url");
+      if (null != epidUrl) {
+        EpidUtils.setEpidOnlineUrl(epidUrl);
       }
     } catch (Exception ex) {
       // intentional fall-through

--- a/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ServerApp.java
+++ b/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ServerApp.java
@@ -57,10 +57,18 @@ public class To0To1ServerApp {
       try (InputStream is = new FileInputStream("application.properties")) {
         properties.load(is);
       }
-      ctx.addParameter("epid_test_mode", properties.getProperty("epid_test_mode"));
+      String epidTestMode = properties.getProperty("epid_test_mode");
+      if (epidTestMode != null) {
+        ctx.addParameter("epid_test_mode", properties.getProperty("epid_test_mode"));
+      }
+      String epidUrl = properties.getProperty("epid_online_url");
+      if (epidUrl != null) {
+        ctx.addParameter("epid_online_url", properties.getProperty("epid_online_url"));
+      }
     } catch (IOException ex) {
       // set default
       ctx.addParameter("epid_test_mode", "false");
+
     }
 
     // To enable remote connections to the DB set


### PR DESCRIPTION
  Fixing AioInfoServlet to return proper error codes on invalid inputs.
  This commit also includes:
  * Minor fix to get-cbor_bytes.sh script.
  * Adding epid_online_url to configurable properties in
    Protocol-samples/T00-TO1server.

Signed-off-by: Davis Benny <davis.benny@intel.com>