### PR TITLE
Upgrading Log4j version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
     <jackson.version>2.12.4</jackson.version>
     <junit-jupiter.version>5.8.0-M1</junit-jupiter.version>
-    <log4j.version>2.14.1</log4j.version>
+    <log4j.version>2.15.0</log4j.version>
     <slf4j.version>1.7.30</slf4j.version>
     <tomcat.version>9.0.52</tomcat.version>
     <cose-java.version>1.1.0</cose-java.version>


### PR DESCRIPTION
  Upgrading Log4j version to 2.15.0 from 2.14.1

  CVE-2021-44228 was issued for Log4j 2.14.1 component.

Signed-off-by: Davis Benny <davis.benny@intel.com>