### PR TITLE
Upgrading log4j version to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
     <jackson.version>2.12.4</jackson.version>
     <junit-jupiter.version>5.8.0-M1</junit-jupiter.version>
-    <log4j.version>2.15.0</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <slf4j.version>1.7.30</slf4j.version>
     <tomcat.version>9.0.52</tomcat.version>
     <cose-java.version>1.1.0</cose-java.version>


### PR DESCRIPTION
  CVE-2021-45046 was issued for Log4j 2.15.0 component.

  It was found that the fix to address CVE-2021-44228 in
  Apache Log4j 2.15.0 was incomplete, hence upgrading.

Signed-off-by: Davis Benny <davis.benny@intel.com>