### PR TITLE
Upgrading dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,14 +29,14 @@
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-configuration2.version>2.7</commons-configuration2.version>
-    <dbcp2.version>2.8.0</dbcp2.version>
+    <dbcp2.version>2.9.0</dbcp2.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-    <h2.version>1.4.200</h2.version>
+    <h2.version>2.0.206</h2.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
-    <jackson.version>2.12.4</jackson.version>
+    <jackson.version>2.12.6</jackson.version>
     <junit-jupiter.version>5.8.0-M1</junit-jupiter.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <slf4j.version>1.7.30</slf4j.version>
     <tomcat.version>9.0.56</tomcat.version>
     <cose-java.version>1.1.0</cose-java.version>


### PR DESCRIPTION
Upgrading dependencies to the latest version
  - H2 version from 1.4.200 to 2.0.206
  - log4j version from 2.17.0 to 2.17.1
  - jackson version from 2.12.4 to 2.12.6
  - dbcp2  version from 2.8.0 to 2.9.0

Signed-off-by: Davis Benny <davis.benny@intel.com>