### PR TITLE
Adding new REST endpoints to protocol

### DIFF
--- a/component-samples/demo/aio/WEB-INF/web.xml
+++ b/component-samples/demo/aio/WEB-INF/web.xml
@@ -109,4 +109,95 @@
       <url-pattern>/api/v1/interop/vouchers/*</url-pattern>
    </servlet-mapping>
 
+    <servlet>
+        <servlet-name>AioRvInfo</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.AioRvInfo</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AioRvInfo</servlet-name>
+        <url-pattern>/api/v1/aio/rvinfo</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>Health</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.HealthApi</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Health</servlet-name>
+        <url-pattern>/health</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>CertificateValidity</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.CertificateValidityApi</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CertificateValidity</servlet-name>
+        <url-pattern>/api/v1/certificate/validity/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>DeviceInfo</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.DeviceInfo</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>DeviceInfo</servlet-name>
+        <url-pattern>/api/v1/deviceinfo/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>CertificateApi</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.CertificateApi</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CertificateApi</servlet-name>
+        <url-pattern>/api/v1/certificate/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MessageSizeApi</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.MessageSizeApi</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MessageSizeApi</servlet-name>
+        <url-pattern>/api/v1/owner/messagesize</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>ServiceInfoSizeApi</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.SviSizeApi</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ServiceInfoSizeApi</servlet-name>
+        <url-pattern>/api/v1/owner/svisize</url-pattern>
+    </servlet-mapping>
+
 </web-app>

--- a/component-samples/demo/aio/service.yml
+++ b/component-samples/demo/aio/service.yml
@@ -7,6 +7,7 @@ hibernate-properties:
 
 system-properties:
   log4j.configurationFile: log4j2.xml
+  application.version: 1.1-SNAPSHOT
   
 
 http-server:

--- a/component-samples/demo/device/service.yml
+++ b/component-samples/demo/device/service.yml
@@ -3,7 +3,7 @@
 
 device:
 
-  di-url: http://fdo10.westus.cloudapp.azure.com:80
+  di-url: http://localhost:8080
 
   credential-file: credentials.bin
  

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/AioRvInfo.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/AioRvInfo.java
@@ -1,0 +1,76 @@
+package org.fidoalliance.fdo.protocol.api;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.fidoalliance.fdo.protocol.Config;
+import org.fidoalliance.fdo.protocol.HttpServer;
+import org.fidoalliance.fdo.protocol.LoggerService;
+import org.fidoalliance.fdo.protocol.Mapper;
+import org.fidoalliance.fdo.protocol.entity.RvData;
+import org.fidoalliance.fdo.protocol.message.RendezvousInfo;
+
+import java.sql.Blob;
+
+/***
+ *  AioRvInfo REST endpoint enables users to set value for RVINFO_BLOB in RV_DATA table
+ *  with IP address and Protocol_type.
+ *
+ *  Accepted URL pattern: POST /api/v1/aio/rvinfo?ip=<ip-address>&rvprot=http/https
+ *
+ *  RestApi Class provides a wrapper over the HttpServletRequest methods.
+ *
+*/
+
+public class AioRvInfo extends RestApi {
+
+  @Override
+  public void doPost() throws Exception {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    LoggerService logger = new LoggerService(AioRvInfo.class);
+
+    try {
+      // Constructing the yaml structure of RvInfo Object.
+      StringBuilder rvi = new StringBuilder("- - - 5\n");
+      String ip = getParamByValue("ip");
+      if (ip != null) {
+        rvi = rvi.append(String.format("    - \"%s\"\n  - - 2\n    - \"%s\"\n", ip, ip));
+      } else {
+        rvi = rvi.append("    - \"localhost\"\n  - - 2\n    - \"127.0.0.1\"\n");
+      }
+
+      String rvProt = getParamByValue("rvprot");
+      if (rvProt != null && rvProt.equals("https")) {
+        rvi = rvi.append("  - - 12\n    - 2\n");
+      } else {
+        // if invalid protocol specified, defaults to http.
+        rvi = rvi.append("  - - 12\n    - 1\n");
+      }
+
+      String port = Config.getWorker(HttpServer.class).getPort();
+      rvi = rvi.append(String.format("  - - 3\n    - %s\n  - - 4\n    - %s", port, port));
+
+      // Creating RendezvousInfo object from yaml structure.
+      RendezvousInfo rviObject = Mapper.INSTANCE.readValue(rvi.toString(), RendezvousInfo.class);
+
+      // Querying DB for RVINFO_BLOB with id=1
+      RvData rviData = getSession().get(RvData.class, Long.valueOf(1));
+
+      if (rviData == null) {
+        // if data doesn't exist in DB, create new row and insert into RV_DATA table.
+        rviData = new RvData();
+        rviData.setData(Mapper.INSTANCE.writeValue(rviObject));
+        getSession().save(rviData);
+      } else {
+        // if data exist in DB, update RV_INFO table with new RVInfo_blob.
+        rviData.setData(Mapper.INSTANCE.writeValue(rviObject));
+        getSession().update(rviData);
+      }
+    } catch (Exception e) {
+      logger.error("Unable to update RVInfo");
+      getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+  }
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/CertificateApi.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/CertificateApi.java
@@ -1,0 +1,99 @@
+package org.fidoalliance.fdo.protocol.api;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.fidoalliance.fdo.protocol.LoggerService;
+import org.fidoalliance.fdo.protocol.entity.CertificateData;
+import java.io.IOException;
+
+
+/***
+ *  CertificateAPI REST endpoint enables users to
+ *     - Collect the keystores stored in the DB based on the filename.
+ *     - Upload new keystores to database.
+ *     - Delete existing keystores in database.
+ *
+ *  Accepted URL patterns :
+ *     - GET /api/v1/certificate?filename=<filename>
+ *     - POST  /api/v1/certificate?filename=<filename> with filecontents in the body
+ *     - DELETE /api/v1/certificate?filename=<filename>
+ *
+ *  RestApi Class provides a wrapper over the HttpServletRequest methods.
+ *
+*/
+
+public class CertificateApi extends RestApi {
+
+  LoggerService logger = new LoggerService(CertificateApi.class);
+
+  @Override
+  public void doGet() throws Exception {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Collect parameter 'filename' from HttpRequest
+    String fileName = getParamByValue("filename");
+
+    // Query database table CERTIFICATE_DATA for filename Key
+    CertificateData certificateData = getSession().get(CertificateData.class, fileName);
+
+    if (certificateData != null) {
+      byte[] data = certificateData.getData();
+      getResponse().getOutputStream().write(data);
+    } else {
+      logger.warn("Keystore file not found.");
+      getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+  }
+
+  @Override
+  public void doPost() throws IOException {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Collect parameter 'filename' from HttpRequest parameter and
+    // uploaded file content from InputStream of request.
+    String fileName = getParamByValue("filename");
+    byte[] keyStoreFile = getRequest().getInputStream().readAllBytes();
+
+    // Query database table CERTIFICATE_DATA for filename Key
+    CertificateData certificateData = getSession().get(CertificateData.class, fileName);
+
+    if (certificateData == null) {
+      // Insert the row, if filename doesn't exist.
+      certificateData = new CertificateData();
+      certificateData.setName(fileName);
+      certificateData.setData(keyStoreFile);
+      getSession().save(certificateData);
+    } else {
+      // Update the row, if filename already exists.
+      certificateData.setData(keyStoreFile);
+      getSession().update(certificateData);
+    }
+
+  }
+
+  @Override
+  public void doDelete() {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Collect parameter 'filename' from HttpRequest
+    String fileName = getParamByValue("filename");
+
+    // Query database table CERTIFICATE_DATA for filename Key
+    CertificateData certificateData = getSession().get(CertificateData.class, fileName);
+
+    if (certificateData != null) {
+      // delete the row, if data exists.
+      getSession().delete(certificateData);
+    } else {
+      logger.warn("Keystore file not found.");
+      getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+  }
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/CertificateValidityApi.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/CertificateValidityApi.java
@@ -1,0 +1,73 @@
+package org.fidoalliance.fdo.protocol.api;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.fidoalliance.fdo.protocol.LoggerService;
+import org.fidoalliance.fdo.protocol.entity.CertificateValidity;
+
+
+/***
+ *  CertificateValidityApi REST endpoint enables users to update
+ *  the default CertificateValidity values in DB.
+ *
+ *  Accepted URL patterns:
+ *     - GET /api/v1/certificate/validity/
+ *     - POST /api/v1/certificate/validity?days=<value>
+ *
+ *  RestApi Class provides a wrapper over the HttpServletRequest methods.
+ *
+*/
+
+public class CertificateValidityApi extends RestApi {
+
+  LoggerService logger = new LoggerService(CertificateValidityApi.class);
+
+  @Override
+  public void doGet() throws Exception {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Query database table CERTIFICATE_VALIDITY for ID `1`.
+    CertificateValidity certificateValidity =
+            getSession().get(CertificateValidity.class, Long.valueOf(1));
+
+    if (certificateValidity != null) {
+      // if not DB is not empty, collect the number of days.
+      int days = certificateValidity.getDays();
+      // Append the days value to the OutputStream of HttpResponse.
+      getResponse().getWriter().write(String.valueOf(days));
+      getResponse().setContentType(getResponseContentType());
+    } else {
+      logger.warn("Certificate validity not found.");
+      getResponse().setStatus(HttpServletResponse.SC_NOT_FOUND);
+    }
+  }
+
+  @Override
+  public void doPost() {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Collect parameter 'days' from HttpRequest.
+    String days = getParamByValue("days");
+
+    // Query database table CERTIFICATE_VALIDITY for ID `1`.
+    CertificateValidity certificateValidity =
+            getSession().get(CertificateValidity.class, Long.valueOf(1));
+    try {
+      int parsedDays = Integer.parseInt(days);
+      certificateValidity.setDays(parsedDays);
+      if (certificateValidity == null) {
+        certificateValidity = new CertificateValidity();
+        getSession().save(certificateValidity);
+        logger.info("Certificate Validity value updated to " + parsedDays);
+      } else {
+        getSession().update(certificateValidity);
+      }
+    } catch (NumberFormatException e)  {
+      logger.error("Invalid days parameter provided");
+      getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+  }
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/DeviceInfo.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/DeviceInfo.java
@@ -1,0 +1,88 @@
+package org.fidoalliance.fdo.protocol.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import org.fidoalliance.fdo.protocol.LoggerService;
+import org.fidoalliance.fdo.protocol.Mapper;
+import org.fidoalliance.fdo.protocol.entity.ManufacturedVoucher;
+import org.fidoalliance.fdo.protocol.message.Guid;
+import org.fidoalliance.fdo.protocol.message.OwnershipVoucher;
+import org.fidoalliance.fdo.protocol.message.OwnershipVoucherHeader;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import java.security.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+
+/***
+ *  DeviceInfo REST endpoint serves information like {guid, serial no & timestamp } of devices
+ *  that completed DI.
+ *
+ *  Accepted URL pattern : GET /api/v1/deviceinfo/*
+ *
+ *  RestApi Class provides a wrapper over the HttpServletRequest methods.
+ *
+*/
+
+public class DeviceInfo extends RestApi {
+
+  @Override
+  public void doGet() throws Exception {
+
+    LoggerService logger = new LoggerService(DeviceInfo.class);
+
+    // Collect pollseconds from the request URL.
+    String pollSeconds = getLastSegment();
+    int pollTime = 0;
+
+    try {
+        pollTime = Integer.parseInt(pollSeconds);
+        if (pollTime <= 0) {
+          logger.warn("Received poll time below 1 second. Defaulting to 20 seconds");
+          pollTime = 20;
+        }
+    } catch (NumberFormatException e) {
+      logger.warn("Received invalid or empty poll time value. Defaulting to 20 seconds");
+      pollTime  = 20;
+    }
+
+    // Retrieve all rows from MANUFACTURED_VOUCHER table.
+    CriteriaBuilder builder = getSession().getCriteriaBuilder();
+    CriteriaQuery<ManufacturedVoucher> criteria = builder.createQuery(ManufacturedVoucher.class);
+    criteria.from(ManufacturedVoucher.class);
+    List<ManufacturedVoucher> vouchers = getSession().createQuery(criteria).getResultList();
+
+    // Creating JSON ObjectMapper object
+    ObjectMapper mapper = new ObjectMapper();
+    ArrayNode rootNode = mapper.createArrayNode();
+
+    for (ManufacturedVoucher voucher : vouchers) {
+
+      // Calculating the time difference between current time and onboarded time.
+      Date createdOn = voucher.getCreatedOn();
+      Date current = new Date(System.currentTimeMillis());
+      long diff =  (current.getTime() - createdOn.getTime())/1000;
+
+      if (diff <= pollTime) {
+        // if time difference is less than polltime. Collect serial no & guid from voucher.
+        // append the data to root JSON node.
+        ObjectNode obj = mapper.createObjectNode();
+        OwnershipVoucher ov = Mapper.INSTANCE.readValue(voucher.getData(), OwnershipVoucher.class);
+        OwnershipVoucherHeader header = Mapper.INSTANCE.readValue(ov.getHeader(), OwnershipVoucherHeader.class);
+        obj.put("serial_no", voucher.getSerialNo());
+        obj.put("timestamp", createdOn.toString());
+        obj.put("uuid", header.getGuid().toString());
+        rootNode.add(obj);
+      }
+    }
+
+    getResponse().getWriter().write(rootNode.toString());
+
+  }
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/HealthApi.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/HealthApi.java
@@ -1,0 +1,44 @@
+package org.fidoalliance.fdo.protocol.api;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.fidoalliance.fdo.protocol.LoggerService;
+
+import java.util.Date;
+
+
+/***
+ *  HealthApi returns the health status of service.
+ *
+ *  Accepted URL pattern: GET /health
+ *
+ *  RestApi Class provides a wrapper over the HttpServletRequest methods.
+ *
+*/
+
+public class HealthApi extends RestApi {
+
+  @Override
+  public void doGet() throws Exception {
+
+    LoggerService logger = new LoggerService(HealthApi.class);
+
+    try {
+
+     String systemTime = new Date().toString();
+     logger.info("Health check invoked at " + systemTime);
+     String responseBody = "{\"version\"= \"%s\"}";
+
+     // Collects property from the service.yml file.
+     String appVersion = System.getProperty("application.version");
+
+     // Appends responseBody to the outputStream of HttpResponse Object.
+     getResponse().getWriter().write(String.format(responseBody, appVersion));
+     getResponse().setContentType("plain/text");
+
+    } catch (Exception e) {
+      logger.error("Unable to perform health check");
+      getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+  }
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/MessageSizeApi.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/MessageSizeApi.java
@@ -1,0 +1,95 @@
+package org.fidoalliance.fdo.protocol.api;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.fidoalliance.fdo.protocol.LoggerService;
+import org.fidoalliance.fdo.protocol.entity.CertificateData;
+import org.fidoalliance.fdo.protocol.entity.OnboardingConfig;
+
+import java.io.IOException;
+
+
+/***
+ *  MessageSizeApi REST endpoint enables users to set and collect MAX_MESSAGE_SIZE value.
+ *  MAX_MESSAGE_SIZE value is used in msg/61.
+ *
+ *  Accepted URL patterns :
+ *         - GET /api/v1/owner/messagesize
+ *         - POST /api/v1/owner/messagesize with message size value in body.
+ *
+ *  RestApi Class provides a wrapper over the HttpServletRequest methods.
+ *
+*/
+
+public class MessageSizeApi extends RestApi {
+
+  LoggerService logger = new LoggerService(MessageSizeApi.class);
+
+  @Override
+  public void doGet() throws Exception {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Query database table ONBOARDING_CONFIG for id `1`.
+    OnboardingConfig config = getSession().get(OnboardingConfig.class, Long.valueOf(1));
+
+    if (config != null) {
+      // if config is not empty, return the MessageSize in HttpResponse body.
+      if (config.getMaxMessageSize() != null) {
+        int messageSize = config.getMaxMessageSize();
+        getResponse().getWriter().write(String.valueOf(messageSize));
+        getResponse().setContentType(getResponseContentType());
+      } else {
+        getResponse().getWriter().write(String.valueOf(0));
+        getResponse().setContentType(getResponseContentType());
+      }
+    } else {
+      logger.warn("Empty Onboarding Config Table.");
+      getResponse().setStatus(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+  }
+
+  @Override
+  public void doPost() throws Exception {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    int messageSize = 0;
+    try {
+      messageSize = Integer.valueOf(getStringBody());
+    } catch (NumberFormatException e) {
+      logger.error("Invalid SVI Threshold size");
+      getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    // Performing input checks on the message size.
+    if (messageSize < 0) {
+      logger.warn("Value below the threshold of 0 bytes. Defaulting to 1500 bytes.");
+      messageSize = 1500;
+    } else if (messageSize > 1500) {
+      logger.warn("Value above the threshold of 1500 bytes. Defaulting to 1500 bytes.");
+      messageSize = 1500;
+    }
+
+    // Query database table ONBOARDING_CONFIG for id `1`.
+    OnboardingConfig config = getSession().get(OnboardingConfig.class, Long.valueOf(1));
+
+    if (config == null) {
+      // If config is empty, insert new row into DB.
+      config = new OnboardingConfig();
+      config.setMaxServiceInfoSize(null);
+      config.setReplacementRvInfo(null);
+      config.setMaxMessageSize(messageSize);
+      getSession().save(config);
+    } else {
+      // Update value of MAX_MESSAGE_SIZE column in ONBOARDING_CONFIG table.
+      config.setMaxMessageSize(messageSize);
+      getSession().update(config);
+    }
+
+  }
+
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/RestApi.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/RestApi.java
@@ -38,6 +38,10 @@ public class RestApi implements AutoCloseable {
     return request;
   }
 
+  protected String getParamByValue(String value) {
+    return request.getParameter(value);
+  }
+
   protected int getReadSize() {
     return READ_SIZE;
   }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/RestApiServlet.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/RestApiServlet.java
@@ -16,7 +16,7 @@ public class RestApiServlet extends HttpServlet {
 
     try (RestApi restApi = (RestApi) Config.loadObject(getInitParameter(API_CLASS))) {
       restApi.init(req,resp);
-      restApi.doPut();
+      restApi.doDelete();
     } catch (NotFoundException e) {
       resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
     } catch (UnsupportedMediaTypeException e) {

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/SviSizeApi.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/api/SviSizeApi.java
@@ -1,0 +1,91 @@
+package org.fidoalliance.fdo.protocol.api;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.fidoalliance.fdo.protocol.LoggerService;
+import org.fidoalliance.fdo.protocol.entity.OnboardingConfig;
+
+
+/***
+ *  SviSizeApi REST endpoint enables users to set and collect MAX_SERVICEINFO_SIZE value.
+ *
+ *  Accepted URL patterns :
+ *         - GET /api/v1/owner/svisize
+ *         - POST /api/v1/owner/svisize with message size value in body.
+ *
+ *  RestApi Class provides a wrapper over the HttpServletRequest methods.
+ *
+*/
+
+public class SviSizeApi extends RestApi {
+
+  LoggerService logger = new LoggerService(SviSizeApi.class);
+
+  @Override
+  public void doGet() throws Exception {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Query database table ONBOARDING_CONFIG for id `1`.
+    OnboardingConfig config = getSession().get(OnboardingConfig.class, Long.valueOf(1));
+
+    if (config != null) {
+      // if config is not empty, return the MessageSize in HttpResponse body.
+      if (config.getMaxServiceInfoSize() != null) {
+        int messageSize = config.getMaxServiceInfoSize();
+        getResponse().getWriter().write(String.valueOf(messageSize));
+        getResponse().setContentType(getResponseContentType());
+      } else {
+        getResponse().getWriter().write(String.valueOf(0));
+        getResponse().setContentType(getResponseContentType());
+      }
+    } else {
+      logger.warn("Empty Onboarding Config Table.");
+      getResponse().setStatus(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+  }
+
+  @Override
+  public void doPost() throws Exception {
+
+    // Create Session object and begin Hibernate transaction.
+    getTransaction();
+
+    // Performing input checks on the SVI message size.
+    int messageSize = 0;
+    try {
+      messageSize = Integer.valueOf(getStringBody());
+    } catch (NumberFormatException e) {
+      logger.error("Invalid SVI Threshold size");
+      getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    if (messageSize < 1300) {
+      logger.warn("Value below the threshold of 1300 bytes. Defaulting to 1300 bytes.");
+      messageSize = 1300;
+    } else if (messageSize > 65536) {
+      logger.warn("Value above the threshold of 65536 bytes. Defaulting to 65536 bytes.");
+      messageSize = 65536;
+    }
+
+    // Query database table ONBOARDING_CONFIG for id `1`.
+    OnboardingConfig config = getSession().get(OnboardingConfig.class, Long.valueOf(1));
+
+    if (config == null) {
+      // If config is empty, insert new row into DB.
+      config = new OnboardingConfig();
+      config.setMaxMessageSize(null);
+      config.setReplacementRvInfo(null);
+      config.setMaxServiceInfoSize(messageSize);
+      getSession().save(config);
+    } else {
+      // Update value of MAX_SERVICEINFO_SIZE column in ONBOARDING_CONFIG table.
+      config.setMaxServiceInfoSize(messageSize);
+      getSession().update(config);
+    }
+
+  }
+
+}


### PR DESCRIPTION
 Following REST endpoints are added to protocol:

  - POST /api/v1/aio/rvinfo?ip=<ip-address>&rvprot=<protocol>

  - GET /health

  - GET api/v1/certificate/validity

  - POST api/v1/certificate/validity?days=<num-of-days>

  - GET /ap1/v1/deviceinfo/{nseconds}
    -- {nseconds} is optional, defaults to 20 seconds

  - GET /api/v1/certificate?filename=filename.p12

  - POST /api/v1/certificate?filename=filename.p12 with file in the body (binary)

  - DELETE /api/v1/certificate?filename=filename.p12

  - GET /api/v1/owner/messagesize

  - POST /api/v1/owner/messagesize  Body with value

  - GET /api/v1/owner/svithreshold

  - POST /api/v1/owner/svithreshold body with value

Signed-off-by: Davis Benny <davis.benny@intel.com>