### PR TITLE
Added replacement voucher API endpoint

### DIFF
--- a/component-samples/demo/aio/service.yml
+++ b/component-samples/demo/aio/service.yml
@@ -11,11 +11,11 @@ system-properties:
   application.version: 1.1-SNAPSHOT
   service.name: "All-in-one demo"
   # set system proxy information
-  #http.proxyHost: proxy-chain.intel.com 
-  #http.proxyPort: 911
-  #https.proxyHost: proxy-chain.intel.com 
-  #https.proxyPort: 912
-  #http.nonProxyHosts: localhost|host.example.com
+  #http.proxyHost:
+  #http.proxyPort:
+  #https.proxyHost:
+  #https.proxyPort:
+  #http.nonProxyHosts:
   
 
 http-server:
@@ -106,7 +106,6 @@ workers:
   - org.fidoalliance.fdo.protocol.StandardManufacturerKeySupplier
   - org.fidoalliance.fdo.protocol.StandardOwnerKeySupplier
   - org.fidoalliance.fdo.protocol.StandardCwtKeySupplier
-  #- org.fidoalliance.fdo.protocol.db.ReuseVoucherReplacementFunction
   - org.fidoalliance.fdo.protocol.StandardReplacementKeySupplier
   - org.fidoalliance.fdo.protocol.SelfSignedHttpClientSupplier
   #- org.fidoalliance.fdo.protocol.HttpOwnerSchemeSupplier 

--- a/component-samples/demo/owner/WEB-INF/web.xml
+++ b/component-samples/demo/owner/WEB-INF/web.xml
@@ -211,6 +211,19 @@
         <url-pattern>/api/v1/owner/svisize</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>Reseller</servlet-name>
+        <servlet-class>org.fidoalliance.fdo.protocol.api.RestApiServlet</servlet-class>
+        <init-param>
+            <param-name>Api-Class</param-name>
+            <param-value>org.fidoalliance.fdo.protocol.api.ResellApi</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Reseller</servlet-name>
+        <url-pattern>/api/v1/resell/*</url-pattern>
+    </servlet-mapping>
+
   <security-constraint>
     <web-resource-collection>
         <web-resource-name>apis</web-resource-name>

--- a/component-samples/demo/owner/service.yml
+++ b/component-samples/demo/owner/service.yml
@@ -103,6 +103,7 @@ workers:
   - org.fidoalliance.fdo.protocol.db.StandardExtraInfoSupplier
   - org.fidoalliance.fdo.protocol.db.StandardVoucherQueryFunction
   - org.fidoalliance.fdo.protocol.db.StandardVoucherReplacementFunction
+  #- org.fidoalliance.fdo.protocol.db.ReuseVoucherReplacementFunction
   - org.fidoalliance.fdo.protocol.db.StandardReplacementVoucherStorageFunction 
   - org.fidoalliance.fdo.protocol.db.StandardRendezvousWaitSecondsSupplier
   - org.fidoalliance.fdo.protocol.db.StandardOwnerInfoSizeSupplier


### PR DESCRIPTION
This PR contains:
  1. Replacement voucher API's endpoint to owner's web.xml
  2. Removing the proxy values from AIO's service.yml and removing a duplicate worker comment
  3. Adding the Reuse worker comment to owner's service.yml


Signed-off-by: Himanshu <himanshu@intel.com>