### PR TITLE
Enabling BasicServiceInfoClientSupplier worker

### DIFF
--- a/component-samples/demo/owner/service.yml
+++ b/component-samples/demo/owner/service.yml
@@ -93,8 +93,8 @@ workers:
   - org.fidoalliance.fdo.protocol.SelfSignedHttpClientSupplier
   #- org.fidoalliance.fdo.protocol.HttpOwnerSchemeSupplier 
   - org.fidoalliance.fdo.protocol.StandardOwnerSchemeSupplier
-  - org.fidoalliance.fdo.protocol.db.StandardServiceInfoClientSupplier
-  #- org.fidoalliance.fdo.protocol.db.BasicServiceInfoClientSupplier
+  #- org.fidoalliance.fdo.protocol.db.StandardServiceInfoClientSupplier
+  - org.fidoalliance.fdo.protocol.db.BasicServiceInfoClientSupplier
   - org.fidoalliance.fdo.protocol.db.OnDieCertificateManager
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreInputStream
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreOutputStream


### PR DESCRIPTION
  Enabling BasicServiceInfoClientSupplier worker by default.

Signed-off-by: Davis Benny <davis.benny@intel.com>