### PR TITLE
Enable Docker build on Ubuntu 22

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -5,7 +5,7 @@ Docker/Podman Script for building `pri-fidoiot` repository. Using this script yo
 
 ## Prerequisites
 
-- Operating system: **Ubuntu 20.04. / RHEL 8.4.**
+- Operating system: **Ubuntu (20.04, 22.04) / RHEL 8.4.**
 
 - Docker engine : **18.09** (Supported till version 20.10.7) / Podman engine (For RHEL).
 

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -32,6 +32,5 @@ services:
     mem_reservation: 1000m
     cpu_shares: 5
     pids_limit: 100
-    network_mode: host
 volumes:
   fdo-m2:


### PR DESCRIPTION
  Enable Docker build on Ubuntu 22.

Signed-off-by: Davis Benny <davis.benny@intel.com>