### PR TITLE
Reading Keystores from FileSystem

### DIFF
--- a/component-samples/demo/aio/README.md
+++ b/component-samples/demo/aio/README.md
@@ -285,6 +285,8 @@ Workers are java classes the implement various behavioral aspects of an FDO serv
 | org.fidoalliance.fdo.protocol.StandardOwnerSchemeSupplier | Tells the owner to use HTTPS for TO0 protocol |
 | org.fidoalliance.fdo.protocol.StandardReplacementKeySupplier | Provides Owner2 keys for for credential replacement during TO2
 | org.fidoalliance.fdo.protocol.UntrustedRendezvousAcceptFunction | Tells the RV server to allow TO0 with untrusted ownership keys
+| org.fidoalliance.fdo.FileKeyStoreInputStream | Loads PRI Service keys from disk |
+| org.fidoalliance.fdo.FileKeyStoreOutputStream | Save PRI Service keys to disk |
 | org.fidoalliance.fdo.protocol.db.AutoInjectVoucherStorageFunction | Automatically extends the voucher to the AIO owner and performs To0 protocol |
 | org.fidoalliance.fdo.protocol.db.BasicServiceInfoClientSupplier| Uses BASIC auth with api_user api_password from service.env for serivceinfo urls (NOT Recommended) |
 

--- a/component-samples/demo/aio/service.yml
+++ b/component-samples/demo/aio/service.yml
@@ -136,6 +136,8 @@ workers:
   - org.fidoalliance.fdo.protocol.db.StandardSessionCleaner
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreInputStream
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreOutputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreInputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreOutputStream
   - org.fidoalliance.fdo.protocol.db.StandardValidityDaysSupplier
   - org.fidoalliance.fdo.protocol.db.StandardRendezvousInfoSupplier
   - org.fidoalliance.fdo.protocol.db.StandardServerSessionManager

--- a/component-samples/demo/manufacturer/service.yml
+++ b/component-samples/demo/manufacturer/service.yml
@@ -86,6 +86,8 @@ workers:
   - org.fidoalliance.fdo.protocol.db.StandardSessionCleaner
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreInputStream
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreOutputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreInputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreOutputStream
   - org.fidoalliance.fdo.protocol.db.StandardValidityDaysSupplier
   - org.fidoalliance.fdo.protocol.db.StandardRendezvousInfoSupplier
   - org.fidoalliance.fdo.protocol.db.StandardServerSessionManager

--- a/component-samples/demo/owner/README.md
+++ b/component-samples/demo/owner/README.md
@@ -197,6 +197,8 @@ Workers are java classes the implement various behavioral aspects of an FDO serv
 | org.fidoalliance.fdo.protocol.StandardOwnerKeySupplier | Provides owner signing keys  |
 | org.fidoalliance.fdo.protocol.StandardOwnerSchemeSupplier | Tells the owner to use HTTPS for TO0 protocol |
 | org.fidoalliance.fdo.protocol.StandardReplacementKeySupplier | Provides Owner2 keys for for credential replacement during TO2
+| org.fidoalliance.fdo.FileKeyStoreInputStream | Loads PRI Service keys from disk |
+| org.fidoalliance.fdo.FileKeyStoreOutputStream | Save PRI Service keys to disk |
 | org.fidoalliance.fdo.protocol.db.BasicServiceInfoClientSupplier| Uses BASIC auth with api_user api_password from service.env for serivceinfo urls (NOT Recommended) |
 | org.fidoalliance.fdo.protocol.db.ConformanceOwnerModule | Provides the implementation of Fido Conformance Module for Interop|
 | org.fidoalliance.fdo.protocol.db.FdoSysOwnerModule | Provides the implementation of the FdoSys Module |

--- a/component-samples/demo/owner/service.yml
+++ b/component-samples/demo/owner/service.yml
@@ -121,6 +121,8 @@ workers:
   - org.fidoalliance.fdo.protocol.db.OnDieCertificateManager
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreInputStream
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreOutputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreInputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreOutputStream
   - org.fidoalliance.fdo.protocol.db.To0Scheduler
   - org.fidoalliance.fdo.protocol.db.StandardSessionCleaner
   - org.fidoalliance.fdo.protocol.db.StandardAcceptOwnerFunction

--- a/component-samples/demo/reseller/README.md
+++ b/component-samples/demo/reseller/README.md
@@ -159,4 +159,6 @@ Workers are java classes the implement various behavioral aspects of an FDO serv
 | org.fidoalliance.fdo.protocol.db.StandardExtraInfoSupplier | Provides null as owner extra data in ownership voucher entries |
 | org.fidoalliance.fdo.protocol.db.StandardKeyStoreInputStream | Provides Keystore loading from a database table |
 | org.fidoalliance.fdo.protocol.db.StandardKeyStoreOutputStream | Provides Keystore storage to a database table |
+| org.fidoalliance.fdo.FileKeyStoreInputStream | Loads PRI Service keys from disk |
+| org.fidoalliance.fdo.FileKeyStoreOutputStream | Save PRI Service keys to disk |
 | org.fidoalliance.fdo.protocol.db.StandardValidityDaysSupplier | Provides the validity days for certificate generation |

--- a/component-samples/demo/reseller/service.yml
+++ b/component-samples/demo/reseller/service.yml
@@ -68,4 +68,6 @@ workers:
   - org.fidoalliance.fdo.protocol.db.StandardExtraInfoSupplier
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreInputStream
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreOutputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreInputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreOutputStream
   - org.fidoalliance.fdo.protocol.db.StandardValidityDaysSupplier

--- a/component-samples/demo/rv/service.yml
+++ b/component-samples/demo/rv/service.yml
@@ -98,6 +98,8 @@ workers:
   - org.fidoalliance.fdo.protocol.StandardCwtKeySupplier
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreInputStream
   - org.fidoalliance.fdo.protocol.db.StandardKeyStoreOutputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreInputStream
+  #- org.fidoalliance.fdo.protocol.FileKeyStoreOutputStream
   - org.fidoalliance.fdo.protocol.db.StandardValidityDaysSupplier
   - org.fidoalliance.fdo.protocol.db.StandardRvBlobQueryFunction
   - org.fidoalliance.fdo.protocol.db.StandardRvBlobStorageFunction

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreInputStream.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreInputStream.java
@@ -1,0 +1,26 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package org.fidoalliance.fdo.protocol;
+
+import org.fidoalliance.fdo.protocol.dispatch.KeyStoreInputStreamFunction;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+public class FileKeyStoreInputStream implements KeyStoreInputStreamFunction {
+
+  @Override
+  public InputStream apply(String path) throws IOException {
+    if (Path.of(path).toFile().exists()) {
+      File inputFile = new File(path);
+      if (inputFile.exists()) {
+        return new FileInputStream(inputFile);
+      }
+    }
+    return null;
+  }
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreInputStream.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreInputStream.java
@@ -3,13 +3,12 @@
 
 package org.fidoalliance.fdo.protocol;
 
-import org.fidoalliance.fdo.protocol.dispatch.KeyStoreInputStreamFunction;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import org.fidoalliance.fdo.protocol.dispatch.KeyStoreInputStreamFunction;
 
 public class FileKeyStoreInputStream implements KeyStoreInputStreamFunction {
 

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreOutputStream.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreOutputStream.java
@@ -3,11 +3,10 @@
 
 package org.fidoalliance.fdo.protocol;
 
-import org.fidoalliance.fdo.protocol.dispatch.KeyStoreOutputStreamFunction;
-
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.fidoalliance.fdo.protocol.dispatch.KeyStoreOutputStreamFunction;
 
 public class FileKeyStoreOutputStream implements KeyStoreOutputStreamFunction {
 

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreOutputStream.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/FileKeyStoreOutputStream.java
@@ -1,0 +1,18 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package org.fidoalliance.fdo.protocol;
+
+import org.fidoalliance.fdo.protocol.dispatch.KeyStoreOutputStreamFunction;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class FileKeyStoreOutputStream implements KeyStoreOutputStreamFunction {
+
+  @Override
+  public OutputStream apply(String s) throws IOException {
+    return new FileOutputStream(s);
+  }
+}


### PR DESCRIPTION
  Adding support for importing keystores from FileSystem.
  Supports PKCS12 formatted Keystores.

Signed-off-by: Davis Benny <davis.benny@intel.com>