### PR TITLE
Upgrading H2 to latest version

### DIFF
--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.1.210</version>
+      <version>2.1.214</version>
     </dependency>
 
 


### PR DESCRIPTION
  Upgrading H2 to latest version:
    H2 database 2.1.210 ==> 2.1.214.

Signed-off-by: Davis Benny <davis.benny@intel.com>