### PR TITLE
Upgrading dependencies to latest version

### DIFF
--- a/component-samples/aio/pom.xml
+++ b/component-samples/aio/pom.xml
@@ -95,13 +95,6 @@
       <version>${postgresql.version}</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.derby/derby -->
-    <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
-      <version>${derby.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,12 @@
     <bcprov.version>1.70</bcprov.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons-text.version>1.9</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-configuration2.version>2.7</commons-configuration2.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-    <jackson.version>2.13.3</jackson.version>
+    <jackson.version>2.14.1</jackson.version>
     <junit-jupiter.version>5.8.2</junit-jupiter.version>
     <log4j.version>2.17.2</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
@@ -45,12 +45,11 @@
     <tomcat.version>10.1.1</tomcat.version>
     <apache-httpcomponents.version>4.5.13</apache-httpcomponents.version>
     <snakeyaml.version>1.32</snakeyaml.version>
-    <jackson-dataformat.version>2.13.3</jackson-dataformat.version>
-    <jackson-databind.version>2.13.3</jackson-databind.version>
+    <jackson-dataformat.version>2.14.1</jackson-dataformat.version>
+    <jackson-databind.version>2.14.1</jackson-databind.version>
     <cose-java.version>1.1.0</cose-java.version>
 
     <!-- Database Client Version -->
-    <derby.version>10.16.1.1</derby.version>
     <h2db.version>2.1.214</h2db.version>
     <mariadb.version>3.0.5</mariadb.version>
     <mysql.version>8.0.31</mysql.version>


### PR DESCRIPTION
   commons-text 1.9 ==> 1.10.0
   jackson-databind 2.13.3 ==> 2.14.2

   removing derby dependency.

Signed-off-by: Davis Benny <davis.benny@intel.com>