### PR TITLE
Updating docker-compose files to be compatible with Ubuntu 20.04 LTS

### DIFF
--- a/component-samples/demo/aio/docker-compose.yml
+++ b/component-samples/demo/aio/docker-compose.yml
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-version: "2.4"
+version: "3.3"
 
 services:
 
@@ -32,10 +32,6 @@ services:
       - ./app-data:/home/fdo/app-data 
     extra_hosts:
      - "host.docker.internal:host-gateway"
-    mem_limit: 500m
-    mem_reservation: 200m
-    cpu_shares: 1024
-    pids_limit: 500
 
 secrets:
   ca-cert.pem:

--- a/component-samples/demo/db/docker-compose.yml
+++ b/component-samples/demo/db/docker-compose.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache 2.0
 
 # Use root/example as user/password credentials
-version: '3.1'
+version: "3.3"
 
 services:
 

--- a/component-samples/demo/device/docker-compose.yml
+++ b/component-samples/demo/device/docker-compose.yml
@@ -1,7 +1,7 @@
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-version: "2.4"
+version: "3.3"
 
 services:
 
@@ -19,8 +19,4 @@ services:
       - ./app-data:/home/fdo/app-data 
     extra_hosts:
      - "host.docker.internal:host-gateway"
-    mem_limit: 500m
-    mem_reservation: 200m
-    cpu_shares: 1024
-    pids_limit: 500
 

--- a/component-samples/demo/manufacturer/docker-compose.yml
+++ b/component-samples/demo/manufacturer/docker-compose.yml
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-version: "2.4"
+version: "3.3"
 
 services:
 
@@ -32,10 +32,6 @@ services:
       - ./app-data:/home/fdo/app-data 
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    mem_limit: 500m
-    mem_reservation: 200m
-    cpu_shares: 1024
-    pids_limit: 500
 
 secrets:
   ca-cert.pem:

--- a/component-samples/demo/owner/docker-compose.yml
+++ b/component-samples/demo/owner/docker-compose.yml
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-version: "2.4"
+version: "3.3"
 
 services:
 
@@ -32,10 +32,6 @@ services:
       - ./app-data:/home/fdo/app-data 
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    mem_limit: 500m
-    mem_reservation: 200m
-    cpu_shares: 1024
-    pids_limit: 500
 
 secrets:
   ca-cert.pem:

--- a/component-samples/demo/reseller/docker-compose.yml
+++ b/component-samples/demo/reseller/docker-compose.yml
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-version: "2.4"
+version: "3.3"
 
 services:
 

--- a/component-samples/demo/rv/docker-compose.yml
+++ b/component-samples/demo/rv/docker-compose.yml
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-version: "2.4"
+version: "3.3"
 
 services:
 


### PR DESCRIPTION
This merge updates all docker-compose.yml files to be compatible with Ubuntu 20.04 LTS and the docker-compose version included in it. It will also fix it for our bare metal onboarding stack.