### PR TITLE
Modifying the default EPID url

### DIFF
--- a/component-samples/demo/aio/service.yml
+++ b/component-samples/demo/aio/service.yml
@@ -83,9 +83,9 @@ epid:
   # fail for non-signature issues (i.e. malformed requests)
   testMode: false
   # TBD: the url below is the used for production purposes
-  # url: http://verify.epid-sbx.trustedservices.intel.com
+  # url: http://verifier.fdorv.com
   # the url below is used for testing purposes only
-  url: http://verify.epid-sbx.trustedservices.intel.com
+  url: http://verifier.fdorv.com
 
 #cbor Web Token (cwt) used for to0 and to1 sessions
 cwt:

--- a/component-samples/demo/manufacturer/service.yml
+++ b/component-samples/demo/manufacturer/service.yml
@@ -69,9 +69,9 @@ epid:
   # fail for non-signature issues (i.e. malformed requests)
   testMode: false
   # TBD: the url below is the used for production purposes
-  # url: http://verify.epid-sbx.trustedservices.intel.com
+  # url: http://verifier.fdorv.com
   # the url below is used for testing purposes only
-  url: http://verify.epid-sbx.trustedservices.intel.com
+  url: http://verifier.fdorv.com
 workers:
   - org.fidoalliance.fdo.protocol.StandardLogProvider
   - org.fidoalliance.fdo.protocol.StandardExceptionConsumer

--- a/component-samples/demo/owner/service.yml
+++ b/component-samples/demo/owner/service.yml
@@ -76,9 +76,9 @@ epid:
   # fail for non-signature issues (i.e. malformed requests)
   testMode: false
   # TBD: the url below is the used for production purposes
-  # url: http://verify.epid-sbx.trustedservices.intel.com
+  # url: http://verifier.fdorv.com
   # the url below is used for testing purposes only
-  url: http://verify.epid-sbx.trustedservices.intel.com
+  url: http://verifier.fdorv.com
 
 
 

--- a/component-samples/demo/rv/service.yml
+++ b/component-samples/demo/rv/service.yml
@@ -72,9 +72,9 @@ epid:
   # fail for non-signature issues (i.e. malformed requests)
   testMode: false
   # TBD: the url below is the used for production purposes
-  # url: http://verify.epid-sbx.trustedservices.intel.com
+  # url: http://verifier.fdorv.com
   # the url below is used for testing purposes only
-  url: http://verify.epid-sbx.trustedservices.intel.com
+  url: http://verifier.fdorv.com
 
 h2-database:
    tcp-server:

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/EpidService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/EpidService.java
@@ -39,7 +39,7 @@ public class EpidService {
   });
   private static final long httpRequestTimeout = Duration.ofSeconds(10).getSeconds();
 
-  private static final String defaultEpidOnlineUrl = "http://verify.epid-sbx.trustedservices.intel.com/";
+  private static final String defaultEpidOnlineUrl = "http://verifier.fdorv.com/";
   private static URI epidOnlineUrl = null;
 
   private static final int EpidGroupLength = 4;

--- a/protocol/src/test/resources/service.yml
+++ b/protocol/src/test/resources/service.yml
@@ -61,9 +61,9 @@ epid:
   # fail for non-signature issues (i.e. malformed requests)
   testMode: false
   # TBD: the url below is the used for production purposes
-  # url: http://verify.epid-sbx.trustedservices.intel.com
+  # url: http://verifier.fdorv.com
   # the url below is used for testing purposes only
-  url: http://verify.epid-sbx.trustedservices.intel.com
+  url: http://verifier.fdorv.com
 
 #cbor Web Token (cwt) used for to0 and to1 sessions
 cwt:


### PR DESCRIPTION
  Modifying the default EPID url to verifier.fdorv.com