### PR TITLE
fix: add missing content-type application/cbor header

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/ProtocolServlet.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/ProtocolServlet.java
@@ -96,6 +96,7 @@ public class ProtocolServlet extends HttpServlet {
 
           resp.setContentLength(errorMsg.getMessage().length);
           resp.getOutputStream().write(errorMsg.getMessage());
+          resp.setContentType(HttpUtils.HTTP_APPLICATION_CBOR);
           logMessage(errorMsg);
 
 


### PR DESCRIPTION
Adds the missing `Content-Type: application/cbor` header to error responses in the FDO protocol servlet.

When the FDO server [throws an exception while processing](https://github.com/fido-device-onboard/pri-fidoiot/blob/master/protocol/src/main/java/org/fidoalliance/fdo/protocol/ProtocolServlet.java#L80-L107) `/fdo/` protocol messages, it returns a CBOR-encoded error in the response body but does not set the `Content-Type` header. [The go-fdo-client checks for this header](https://github.com/fido-device-onboard/go-fdo/blob/9b5f6fde4236ddef04fb688969cb001530a7e171/http/transport.go#L132) before parsing response bodies so it silently ignores these error messages when the header is missing.                                                                                                                                                                                     

This PR set `Content-Type: application/cbor` on error responses in `ProtocolServlet.java`, matching the behavior for successful responses.